### PR TITLE
Fix errors when performing operations on invalid gateway

### DIFF
--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -467,7 +467,6 @@ class Disks(UIGroup):
         self.logger.debug("Starting delete for rbd {}".format(image_id))
 
         local_gw = this_host()
-        # other_gateways = get_other_gateways(self.parent.target.children)
 
         api_vars = {'purge_host': local_gw}
 


### PR DESCRIPTION
This PR will fix the following error when performing a disk operation on a machine that is not a valid gateway:

`Failed : Unhandled exception: list.remove(x): x not in list`

**How to reproduce**

Given the following configuration:

```
  o- disks .............................................................. [0.00Y, Disks: 0]
  o- iscsi-target ............................................................ [Targets: 1]
    o- iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw ............................ [Gateways: 2]
      o- gateways ................................................... [Up: 2/2, Portals: 2]
      | o- node2 ................................................... [192.168.100.202 (UP)]
      | o- node3 ................................................... [192.168.100.203 (UP)]
      o- host-groups ......................................................... [Groups : 0]
      o- hosts ..................................................... [Hosts: 0: Auth: None]
```
Execute the following on `node1`:
```
[@node1] gwcli
/> cd disks 
/disks> create pool=rbd image=disk_1 size=90G
Failed : Unhandled exception: list.remove(x): x not in list
```


Signed-off-by: Ricardo Marques <rimarques@suse.com>