### PR TITLE
Use the correct logger to log API exception

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -108,7 +108,7 @@ def requires_restricted_auth(f):
 
 @app.errorhandler(Exception)
 def unhandled_exception(e):
-    app.logger.exception("Unhandled Exception")
+    logger.exception("Unhandled Exception")
     return jsonify(message="Unhandled exception: {}".format(e)), 500
 
 


### PR DESCRIPTION
With this PR, all API exceptions will be logged into `rbd-target-api.log` file.

Signed-off-by: Ricardo Marques <rimarques@suse.com>