### PR TITLE
Multiple iSCSI target support (and more...)

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -29,18 +29,19 @@ class GWClient(GWObject):
                 "nopin_timeout",
                 "cmdsn_depth"]
 
-    seed_metadata = {"auth": {"chap": ''},
+    seed_metadata = {"auth": {"chap": '', "chap_mutual": ''},
                      "luns": {},
                      "group_name": ""
                      }
 
-    def __init__(self, logger, client_iqn, image_list, chap, target_iqn):
+    def __init__(self, logger, client_iqn, image_list, chap, chap_mutual, target_iqn):
         """
         Instantiate an instance of an LIO client
         :param client_iqn: (str) iscsi iqn string
         :param image_list: (list) list of rbd images (pool/image) to attach
                            to this client or list of tuples (disk, lunid)
         :param chap: (str) chap credentials in the format 'user/password'
+        :param chap_mutual: (str) chap_mutual credentials in the format 'user/password'
         :param target_iqn: (str) target iqn string
         :return:
         """
@@ -66,6 +67,7 @@ class GWClient(GWObject):
                 self.requested_images = image_list
 
         self.chap = chap                        # parameters for auth
+        self.chap_mutual = chap_mutual          # parameters for mutual auth
         self.mutual = ''
         self.tpgauth = ''
         self.metadata = {}
@@ -235,6 +237,7 @@ class GWClient(GWObject):
         for client_iqn in target_config['clients']:
             client_metadata = target_config['clients'][client_iqn]
             client_chap = CHAP(client_metadata['auth']['chap'])
+            client_chap_mutual = CHAP(client_metadata['auth']['chap_mutual'])
 
             image_list = client_metadata['luns'].keys()
 
@@ -243,11 +246,17 @@ class GWClient(GWObject):
                 raise CephiSCSIError("Unable to decode password for {}. "
                                      "CHAP error: {}".format(client_iqn,
                                                              client_chap.error_msg))
+            chap_mutual_str = client_chap_mutual.chap_str
+            if client_chap_mutual.error:
+                raise CephiSCSIError("Unable to decode password for {}. "
+                                     "CHAP_MUTUAL error: {}".format(client_iqn,
+                                                                    client_chap.error_msg))
 
             client = GWClient(logger,
                               client_iqn,
                               image_list,
                               chap_str,
+                              chap_mutual_str,
                               target_iqn)
 
             client.manage('present')  # ensure the client exists
@@ -266,71 +275,91 @@ class GWClient(GWObject):
 
         tpg.set_attribute('authentication', '0')
 
-    def configure_auth(self, auth_type, credentials):
+    def configure_auth(self, chap_credentials, chap_mutual_credentials):
         """
         Attempt to configure authentication for the client
         :return:
         """
 
-        chap_enabled = False
-        if '/' in credentials:
-            client_username, client_password = credentials.split('/', 1)
-            chap_enabled = True
-        elif not credentials:
+        auth_enabled = False
+        if '/' in chap_credentials:
+            client_username, client_password = chap_credentials.split('/', 1)
+            auth_enabled = True
+        elif not chap_credentials:
             client_username = ''
             client_password = ''
-            credentials = "/"
+            chap_credentials = "/"
 
-        self.logger.debug("configuring auth {}".format(credentials))
+        if '/' in chap_mutual_credentials:
+            client_mutual_username, client_mutual_password = chap_mutual_credentials.split('/', 1)
+            auth_enabled = True
+        elif not chap_mutual_credentials:
+            client_mutual_username = ''
+            client_mutual_password = ''
+            chap_mutual_credentials = "/"
 
-        if auth_type == 'chap':
+        self.logger.debug("configuring auth chap={}, chap_mutual={}".format(
+            chap_credentials, chap_mutual_credentials))
 
-            acl_credentials = "{}/{}".format(self.acl.chap_userid,
-                                             self.acl.chap_password)
+        acl_credentials = "{}/{}".format(self.acl.chap_userid,
+                                         self.acl.chap_password)
+        acl_mutual_credentials = "{}/{}".format(self.acl.chap_mutual_userid,
+                                                self.acl.chap_mutual_password)
 
-            # if the credentials match... nothing to do
-            if credentials == acl_credentials:
-                return
-            else:
-                # credentials defined on the ACL don't match parms passed from
-                # caller so update the acl definition
-                try:
-                    if auth_type == 'chap':
-                        self.logger.debug("Updating the ACL")
-                        self.acl.chap_userid = client_username
-                        self.acl.chap_password = client_password
+        try:
+            self.logger.debug("Updating the ACL")
+            if chap_credentials != acl_credentials:
+                self.acl.chap_userid = client_username
+                self.acl.chap_password = client_password
 
-                        new_chap = CHAP(credentials)
-                        self.logger.debug("chap object set to: {},{},{},{}".format(
-                            new_chap.chap_str, new_chap.user, new_chap.password,
-                            new_chap.password_str))
+                new_chap = CHAP(chap_credentials)
+                self.logger.debug("chap object set to: {},{},{},{}".format(
+                    new_chap.chap_str, new_chap.user, new_chap.password,
+                    new_chap.password_str))
 
-                        new_chap.chap_str = "{}/{}".format(client_username,
-                                                           client_password)
-                        if new_chap.error:
-                            self.error = True
-                            self.error_msg = new_chap.error_msg
-                            return
-
-                        if chap_enabled:
-                            self.tpg.set_attribute('authentication', '1')
-                        else:
-                            self.try_disable_auth(self.tpg)
-
-                        self.logger.debug("Updating config object meta data")
-                        self.metadata['auth']['chap'] = new_chap.chap_str
-
-                except RTSLibError as err:
+                new_chap.chap_str = "{}/{}".format(client_username,
+                                                   client_password)
+                if new_chap.error:
                     self.error = True
-                    self.error_msg = ("Unable to configure {} authentication "
-                                      "for {} - ".format(auth_type,
-                                                         self.iqn,
-                                                         err))
-                    self.logger.error("Client.configure_auth) failed to set "
-                                      "{} credentials for {}".format(auth_type,
-                                                                     self.iqn))
-                else:
-                    self.change_count += 1
+                    self.error_msg = new_chap.error_msg
+                    return
+
+            if chap_mutual_credentials != acl_mutual_credentials:
+                self.acl.chap_mutual_userid = client_mutual_username
+                self.acl.chap_mutual_password = client_mutual_password
+
+                new_chap_mutual = CHAP(chap_mutual_credentials)
+                self.logger.debug("chap mutual object set to: {},{},{},{}".format(
+                    new_chap_mutual.chap_str, new_chap_mutual.user, new_chap_mutual.password,
+                    new_chap_mutual.password_str))
+
+                new_chap_mutual.chap_str = "{}/{}".format(client_mutual_username,
+                                                          client_mutual_password)
+                if new_chap_mutual.error:
+                    self.error = True
+                    self.error_msg = new_chap_mutual.error_msg
+                    return
+
+            if auth_enabled:
+                self.tpg.set_attribute('authentication', '1')
+            else:
+                self.try_disable_auth(self.tpg)
+
+            self.logger.debug("Updating config object meta data")
+            if chap_credentials != acl_credentials:
+                self.metadata['auth']['chap'] = new_chap.chap_str
+            if chap_mutual_credentials != acl_mutual_credentials:
+                self.metadata['auth']['chap_mutual'] = new_chap_mutual.chap_str
+
+        except RTSLibError as err:
+            self.error = True
+            self.error_msg = ("Unable to configure authentication "
+                              "for {} - ".format(self.iqn,
+                                                 err))
+            self.logger.error("(Client.configure_auth) failed to set "
+                              "credentials for {}".format(self.iqn))
+        else:
+            self.change_count += 1
 
     def _add_lun(self, image, lun):
         """
@@ -492,8 +521,16 @@ class GWClient(GWObject):
                     self.error = True
                     self.error_msg = config_chap.error_msg
                     return
+                # extract the chap_mutual_str from the config object entry
+                config_chap_mutual = CHAP(self.metadata['auth']['chap_mutual'])
+                chap_mutual_str = config_chap_mutual.chap_str
+                if config_chap_mutual.error:
+                    self.error = True
+                    self.error_msg = config_chap_mutual.error_msg
+                    return
 
                 if self.chap == chap_str and \
+                   self.chap_mutual == chap_mutual_str and \
                    config_image_list == sorted(self.requested_images):
                     self.commit_enabled = False
             else:
@@ -531,12 +568,11 @@ class GWClient(GWObject):
                                       "for {}".format(bad_images, self.iqn))
                     return
 
-            # if '/' in self.chap:
-            if self.chap == '':
+            if self.chap == '' and self.chap_mutual == '':
                 self.logger.warning("(main) client '{}' configured without"
                                     " security".format(self.iqn))
 
-            self.configure_auth('chap', self.chap)
+            self.configure_auth(self.chap, self.chap_mutual)
             if self.error:
                 return
 

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -188,8 +188,6 @@ class Config(object):
             for _, group in self.config['groups'].items():
                 group.pop('created', None)
                 group.pop('updated', None)
-            for _, disk in self.config['disks'].items():
-                disk['allocating_host'] = disk['owner']
             target = {
                 'disks': list(self.config['disks'].keys()),
                 'clients': self.config['clients'],

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -185,6 +185,7 @@ class Config(object):
             for _, client in self.config['clients'].items():
                 client.pop('created', None)
                 client.pop('updated', None)
+                client['auth']['chap_mutual'] = ''
             for _, group in self.config['groups'].items():
                 group.pop('created', None)
                 group.pop('updated', None)

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -52,6 +52,8 @@ class Config(object):
     seed_config = {"disks": {},
                    "gateways": {},
                    "targets": {},
+                   "discovery_auth": {'chap': '',
+                                      'chap_mutual': ''},
                    "version": 4,
                    "epoch": 0,
                    "created": '',
@@ -197,6 +199,10 @@ class Config(object):
                 'controls': self.config['controls'],
                 'ip_list': self.config['gateways']['ip_list']
             }
+            self.add_item('discovery_auth', None, {
+                'chap': '',
+                'chap_mutual': ''
+            })
             self.add_item("targets", None, {})
             self.add_item("targets", iqn, target)
             self.update_item("targets", iqn, target)

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -188,6 +188,8 @@ class Config(object):
             for _, group in self.config['groups'].items():
                 group.pop('created', None)
                 group.pop('updated', None)
+            for _, disk in self.config['disks'].items():
+                disk['allocating_host'] = disk['owner']
             target = {
                 'disks': list(self.config['disks'].keys()),
                 'clients': self.config['clients'],

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -80,6 +80,7 @@ class Config(object):
 
         if self.init_config():
             self.config = self.get_config()
+            self._upgrade_config()
             self.changed = False
 
     def _read_config_object(self, ioctx):
@@ -153,6 +154,16 @@ class Config(object):
         cfg_dict = json.loads(cfg_data)
 
         return cfg_dict
+
+    def _upgrade_config(self):
+        if self.config['version'] >= Config.seed_config['version']:
+            return
+
+        if self.config['version'] <= 2:
+            self.add_item("groups", element_name=None, initial_value={})
+            self.update_item("version", element_name=None, element_value=3)
+
+        self.commit("retain")
 
     def init_config(self):
         try:
@@ -238,6 +249,7 @@ class Config(object):
     def refresh(self):
         self.logger.debug("config refresh - current config is {}".format(self.config))
         self.config = self.get_config()
+        self._upgrade_config()
 
     def add_item(self, cfg_type, element_name=None, initial_value=None):
         now = get_time()

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -51,9 +51,8 @@ class Config(object):
 
     seed_config = {"disks": {},
                    "gateways": {},
-                   "clients": {},
-                   "groups": {},
-                   "version": 3,
+                   "targets": {},
+                   "version": 4,
                    "epoch": 0,
                    "created": '',
                    "updated": ''
@@ -162,6 +161,49 @@ class Config(object):
         if self.config['version'] <= 2:
             self.add_item("groups", element_name=None, initial_value={})
             self.update_item("version", element_name=None, element_value=3)
+
+        if self.config['version'] == 3:
+            iqn = self.config['gateways']['iqn']
+            gateways = {}
+            portals = {}
+            for host, gateway_v3 in self.config['gateways'].items():
+                if isinstance(gateway_v3, dict):
+                    portal = gateway_v3
+                    portal.pop('iqn')
+                    active_luns = portal.pop('active_luns')
+                    updated = portal.pop('updated', None)
+                    created = portal.pop('created', None)
+                    gateway = {
+                        'active_luns': active_luns
+                    }
+                    if created:
+                        gateway['created'] = created
+                    if updated:
+                        gateway['updated'] = updated
+                    gateways[host] = gateway
+                    portals[host] = portal
+            for _, client in self.config['clients'].items():
+                client.pop('created', None)
+                client.pop('updated', None)
+            for _, group in self.config['groups'].items():
+                group.pop('created', None)
+                group.pop('updated', None)
+            target = {
+                'disks': list(self.config['disks'].keys()),
+                'clients': self.config['clients'],
+                'portals': portals,
+                'groups': self.config['groups'],
+                'controls': self.config['controls'],
+                'ip_list': self.config['gateways']['ip_list']
+            }
+            self.add_item("targets", None, {})
+            self.add_item("targets", iqn, target)
+            self.update_item("targets", iqn, target)
+            self.del_item('controls', None)
+            self.del_item('clients', None)
+            self.del_item('groups', None)
+            self.update_item("gateways", None, gateways)
+            self.update_item("version", None, 4)
 
         self.commit("retain")
 
@@ -288,7 +330,10 @@ class Config(object):
 
     def del_item(self, cfg_type, element_name):
         self.changed = True
-        del self.config[cfg_type][element_name]
+        if element_name:
+            del self.config[cfg_type][element_name]
+        else:
+            del self.config[cfg_type]
         self.logger.debug("(Config.del_item) config updated to {}".format(self.config))
 
         txn = ConfigTransaction(cfg_type, element_name, 'delete')
@@ -353,7 +398,10 @@ class Config(object):
                     current_config[txn.type] = txn.item_content
 
             elif txn.action == 'delete':
-                del current_config[txn.type][txn.item_name]
+                if txn.item_name:
+                    del current_config[txn.type][txn.item_name]
+                else:
+                    del current_config[txn.type]
             else:
                 self.error = True
                 self.error_msg = "Unknown transaction type ({}} encountered in " \

--- a/ceph_iscsi_config/discovery.py
+++ b/ceph_iscsi_config/discovery.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+from rtslib_fb.fabric import ISCSIFabricModule
+
+from ceph_iscsi_config.client import CHAP
+
+
+class Discovery(object):
+
+    @staticmethod
+    def validate_discovery_auth(chap_str, chap_mutual_str):
+        if chap_str != '' and '/' not in chap_str:
+            return 'CHAP format is invalid - must be a <username>/<password> format'
+        if chap_mutual_str != '' and '/' not in chap_mutual_str:
+            return 'CHAP_MUTUAL format is invalid - must be a <username>/<password> format'
+        return None
+
+    @staticmethod
+    def set_discovery_auth_lio(chap_str, chap_mutual_str):
+        iscsi_fabric = ISCSIFabricModule()
+        if chap_str == '':
+            iscsi_fabric.clear_discovery_auth_settings()
+        else:
+            chap = CHAP(chap_str)
+            chap_mutual = CHAP(chap_mutual_str)
+            iscsi_fabric.discovery_userid = chap.user
+            iscsi_fabric.discovery_password = chap.password
+            iscsi_fabric.discovery_mutual_userid = chap_mutual.user
+            iscsi_fabric.discovery_mutual_password = chap_mutual.password
+            iscsi_fabric.discovery_enable_auth = True
+
+    @staticmethod
+    def set_discovery_auth_config(chap_str, chap_mutual_str, config):
+        discovery_auth_config = {
+            'chap': '',
+            'chap_mutual': ''
+        }
+        if chap_str != '':
+            discovery_auth_config['chap'] = chap_str
+            discovery_auth_config['chap_mutual'] = chap_mutual_str
+        config.update_item('discovery_auth', '', discovery_auth_config)

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -193,7 +193,7 @@ class GWTarget(GWObject):
                 else:
                     break
 
-    def clear_config(self, target_disks, unmapped_disks):
+    def clear_config(self, target_disks):
         """
         Remove the target definition form LIO
         :return: None
@@ -202,7 +202,7 @@ class GWTarget(GWObject):
         lio_root = root.RTSRoot()
 
         disk_count = len([disk for disk in lio_root.storage_objects
-                          if disk.name in target_disks or disk.name in unmapped_disks])
+                          if disk.name in target_disks])
         clients = []
         for tpg in self.tpg_list:
             tpg_clients = [node for node in tpg._list_node_acls()]
@@ -577,9 +577,7 @@ class GWTarget(GWObject):
 
             target_config = config.config["targets"][self.iqn]
             target_disks = target_config['disks']
-            unmapped_disks = [key for key, value in config.config['disks'].items()
-                              if not value.get('owner')]
-            self.clear_config(target_disks, unmapped_disks)
+            self.clear_config(target_disks)
 
             if not self.error:
                 gw_ip = target_config['portals'][local_gw]['portal_ip_address']

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -14,6 +14,7 @@ from ceph_iscsi_config.utils import (normalize_ip_address, normalize_ip_literal,
                                      ip_addresses, this_host, format_lio_yes_no,
                                      CephiSCSIError, CephiSCSIInval)
 from ceph_iscsi_config.common import Config
+from ceph_iscsi_config.discovery import Discovery
 from ceph_iscsi_config.alua import alua_create_group, alua_format_group_name
 from ceph_iscsi_config.client import GWClient
 from ceph_iscsi_config.gateway_object import GWObject
@@ -289,6 +290,7 @@ class GWTarget(GWObject):
                 if self.error:
                     self.logger.critical("Unable to create the TPG for {} "
                                          "- {}".format(ip, self.error_msg))
+
             self.update_tpg_controls()
 
         except RTSLibError as err:
@@ -485,6 +487,9 @@ class GWTarget(GWObject):
                 # return to caller, with error state set
                 return
 
+            Discovery.set_discovery_auth_lio(config.config['discovery_auth']['chap'],
+                                             config.config['discovery_auth']['chap_mutual'])
+
             target_config = config.config["targets"][self.iqn]
             gateway_group = config.config["gateways"].keys()
             if "ip_list" not in target_config:
@@ -566,6 +571,9 @@ class GWTarget(GWObject):
                 }
                 config.add_item("targets", self.iqn, seed_target)
                 config.commit()
+
+                Discovery.set_discovery_auth_lio(config.config['discovery_auth']['chap'],
+                                                 config.config['discovery_auth']['chap_mutual'])
 
         elif mode == 'clearconfig':
             # Called by API from CLI clearconfig command

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -597,7 +597,7 @@ class GWTarget(GWObject):
 
                     ip_list = target_config['ip_list']
                     ip_list.remove(gw_ip)
-                    if len(ip_list) > 0:
+                    if len(ip_list) > 0 and len(target_config['portals'].keys()) > 0:
                         config.update_item('targets', self.iqn, target_config)
                     else:
                         # no more portals in the list, so delete the target

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -375,7 +375,7 @@ class GWTarget(GWObject):
             # someone mapped a LU then unmapped it without deleting the
             # stg_object, or we are reloading the config.
             alua_tpg = ALUATargetPortGroup(stg_object, group_name)
-            if alua_tpg.tpg_id != tpg.tag:
+            if alua_tpg.tg_pt_gp_id != tpg.tag:
                 # ports and owner were rearranged. Not sure we support that.
                 raise CephiSCSIInval("Existing ALUA group tag for group {} "
                                      "in invalid state.\n".format(group_name))

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -573,33 +573,37 @@ class GWTarget(GWObject):
                 self.load_config()
             else:
                 self.error = True
-                self.error_msg = "IQN provided does not exist"
+                self.error_msg = "Target {} does not exist on {}".format(self.iqn, local_gw)
+                return
 
             target_config = config.config["targets"][self.iqn]
             target_disks = target_config['disks']
             self.clear_config(target_disks)
 
             if not self.error:
-                gw_ip = target_config['portals'][local_gw]['portal_ip_address']
-
-                target_config['portals'].pop(local_gw)
-
-                ip_list = target_config['ip_list']
-                ip_list.remove(gw_ip)
-                if len(ip_list) > 0:
-                    config.update_item('targets', self.iqn, target_config)
-                else:
-                    # no more portals in the list, so delete the target
+                if len(target_config['portals']) == 0:
                     config.del_item('targets', self.iqn)
+                else:
+                    gw_ip = target_config['portals'][local_gw]['portal_ip_address']
 
-                remove_gateway = True
-                for _, target in config.config["targets"].items():
-                    if local_gw in target['portals']:
-                        remove_gateway = False
-                        break
+                    target_config['portals'].pop(local_gw)
 
-                if remove_gateway:
-                    # gateway is no longer used, so delete it
-                    config.del_item('gateways', local_gw)
+                    ip_list = target_config['ip_list']
+                    ip_list.remove(gw_ip)
+                    if len(ip_list) > 0:
+                        config.update_item('targets', self.iqn, target_config)
+                    else:
+                        # no more portals in the list, so delete the target
+                        config.del_item('targets', self.iqn)
+
+                    remove_gateway = True
+                    for _, target in config.config["targets"].items():
+                        if local_gw in target['portals']:
+                            remove_gateway = False
+                            break
+
+                    if remove_gateway:
+                        # gateway is no longer used, so delete it
+                        config.del_item('gateways', local_gw)
 
                 config.commit()

--- a/ceph_iscsi_config/gateway_object.py
+++ b/ceph_iscsi_config/gateway_object.py
@@ -22,16 +22,9 @@ class GWObject(object):
         self._add_properies()
 
     def _set_config_controls(self, config, controls):
-        if self.cfg_type_key:
-            config.config[self.cfg_type][self.cfg_type_key]['controls'] = controls
-        else:
-            config.config['controls'] = controls
+        config.config[self.cfg_type][self.cfg_type_key]['controls'] = controls
 
     def _get_config_controls(self):
-        # global controls
-        if self.cfg_type == 'controls':
-            return self.config.config.get('controls', {})
-
         # This might be the initial creation so it will not be in the
         # config yet
         if self.cfg_type_key in self.config.config[self.cfg_type]:
@@ -67,14 +60,9 @@ class GWObject(object):
             # update our config
             self._set_config_controls(self.config, self.controls)
 
-            # update remote config
-            if self.cfg_type == 'controls':
-                self.config.update_item(self.cfg_type, self.cfg_type_key,
-                                        self.controls)
-            else:
-                updated_obj = self.config.config[self.cfg_type][self.cfg_type_key]
-                self.config.update_item(self.cfg_type, self.cfg_type_key,
-                                        updated_obj)
+            updated_obj = self.config.config[self.cfg_type][self.cfg_type_key]
+            self.config.update_item(self.cfg_type, self.cfg_type_key,
+                                    updated_obj)
 
         self.config.commit()
         if self.config.error:

--- a/ceph_iscsi_config/group.py
+++ b/ceph_iscsi_config/group.py
@@ -35,9 +35,6 @@ class Group(object):
             self.error_msg = self.config.error_msg
             return
 
-        # check that the config object has a group section
-        Group._check_config(self.logger, self.config)
-
         self.group_name = group_name
         self.group_members = members
         self.disks = disks
@@ -50,30 +47,6 @@ class Group(object):
         self.logger.debug("Group : name={}".format(self.group_name))
         self.logger.debug("Group : members={}".format(self.group_members))
         self.logger.debug("Group : disks={}".format(self.disks))
-
-    @classmethod
-    def _check_config(cls, logger, config_object):
-        """
-        look at the current config object to determine whether it needs the
-        group section seeding
-        :param logger: (logging object) destination for log messages
-        :param config_object: Instance of the Config class
-        :return: Null
-        """
-
-        if 'groups' in config_object.config:
-            logger.debug("Config object contains a 'groups' section - config "
-                         "object upgrade is not required")
-            return
-        else:
-            # Need to upgrade the config object to include the new
-            # 'groups' section
-            logger.info("Adding 'groups' section to config object")
-            config_object.add_item("groups", element_name=None,
-                                   initial_value={})
-            config_object.update_item("version", element_name=None,
-                                      element_value=3)
-            config_object.commit()
 
     def __str__(self):
         return ("Group: {}\n- Members: {}\n- "

--- a/ceph_iscsi_config/group.py
+++ b/ceph_iscsi_config/group.py
@@ -314,7 +314,7 @@ class Group(object):
 
     def update_client(self, client_iqn, image_list):
 
-        client = GWClient(self.logger, client_iqn, image_list, '', self.target_iqn)
+        client = GWClient(self.logger, client_iqn, image_list, '', '', self.target_iqn)
         client.manage('reconfigure')
 
         # grab the client's metadata from the config (needed by setup_luns)

--- a/ceph_iscsi_config/lio.py
+++ b/ceph_iscsi_config/lio.py
@@ -54,10 +54,9 @@ class Gateway(LIO):
     def drop_target(self, this_host):
         if this_host in self.config.config['gateways']:
 
-            iqn = self.config.config['gateways'][this_host]['iqn']
-
             lio_root = root.RTSRoot()
             for tgt in lio_root.targets:
-                if tgt.wwn == iqn:
+                if tgt.wwn in self.config.config['targets'] \
+                        and this_host in self.config.config['targets'][tgt.wwn]['portals']:
                     tgt.delete()
                     self.changed = True

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -344,7 +344,8 @@ class LUN(GWObject):
 
         # Now we know the request is for a LUN in LIO, and it's not masked
         # to a client
-        self.remove_dev_from_lio(False)
+        remove_from_backstore = this_host != self.allocating_host
+        self.remove_dev_from_lio(remove_from_backstore)
         if self.error:
             return
 

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -449,7 +449,14 @@ class LUN(GWObject):
                     raise CephiSCSIError("Password decode issue : "
                                          "{}".format(client_chap.error_msg))
 
-                client = GWClient(self.logger, client_iqn, image_list, chap_str, target_iqn)
+                client_chap_mutual = CHAP(client_metadata['auth']['chap_mutual'])
+                chap_mutual_str = client_chap_mutual.chap_str
+                if client_chap_mutual.error:
+                    raise CephiSCSIError("Password decode issue : "
+                                         "{}".format(client_chap_mutual.error_msg))
+
+                client = GWClient(self.logger, client_iqn, image_list, chap_str,
+                                  chap_mutual_str, target_iqn)
                 client.manage('present')
                 if client.error:
                     client_err = "LUN mapping failed {} - {}".format(client_iqn,

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -204,11 +204,13 @@ class Clients(UIGroup):
             return
 
         for client in self.children:
-            client.set_auth(chap)
+            client.set_auth(chap, None)
 
     def summary(self):
         chap_enabled = False
         chap_disabled = False
+        chap_mutual_enabled = False
+        chap_mutual_disabled = False
         status = False
         # initiator name based ACL is the default with the current kernel
         # settings.
@@ -220,13 +222,22 @@ class Clients(UIGroup):
             else:
                 chap_enabled = True
 
-            if chap_enabled and chap_disabled:
+            if client.auth['chap_mutual'] == 'None':
+                chap_mutual_disabled = True
+            else:
+                chap_mutual_enabled = True
+
+            if chap_enabled and chap_disabled or \
+                    chap_mutual_enabled and chap_mutual_disabled:
                 auth_stat_str = "MISCONFIG"
                 status = False
                 break
 
         if auth_stat_str != "MISCONFIG":
-            if chap_enabled:
+            if chap_mutual_enabled:
+                auth_stat_str = "CHAP_MUTUAL"
+                status = True
+            elif chap_enabled:
                 auth_stat_str = "CHAP"
                 status = True
 
@@ -263,7 +274,7 @@ class Client(UINode):
         for k, v in client_settings.items():
             self.__setattr__(k, v)
 
-        # decode the password if necessary
+        # decode the chap password if necessary
         if 'chap' in self.auth:
             self.chap = CHAP(self.auth['chap'])
 
@@ -273,6 +284,17 @@ class Client(UINode):
                 self.auth['chap'] = "None"
         else:
             self.auth['chap'] = "None"
+
+        # decode the chap_mutual password if necessary
+        if 'chap_mutual' in self.auth:
+            self.chap_mutual = CHAP(self.auth['chap_mutual'])
+
+            if self.chap_mutual.chap_str != '':
+                self.auth['chap_mutual'] = self.chap_mutual.chap_str
+            else:
+                self.auth['chap_mutual'] = "None"
+        else:
+            self.auth['chap_mutual'] = "None"
 
         self.refresh_luns()
 
@@ -307,10 +329,12 @@ class Client(UINode):
         auth_text = "Auth: None"
         status = False
 
-        if 'chap' in self.auth:
-            if self.auth['chap'] != 'None':
-                auth_text = "Auth: CHAP"
-                status = True
+        if 'chap_mutual' in self.auth and self.auth['chap_mutual'] != 'None':
+            auth_text = "Auth: CHAP_MUTUAL"
+            status = True
+        elif 'chap' in self.auth and self.auth['chap'] != 'None':
+            auth_text = "Auth: CHAP"
+            status = True
 
         msg.append(auth_text)
 
@@ -319,13 +343,15 @@ class Client(UINode):
 
         return ", ".join(msg), status
 
-    def set_auth(self, chap=None):
+    def set_auth(self, chap=None, chap_mutual=None):
+
+        self.logger.warn("chap={}, chap_mutual={}".format(chap, chap_mutual))
 
         self.logger.debug("CMD: ../hosts/<client_iqn> auth *")
 
         if not chap:
             self.logger.error("To set or reset authentication, specify either "
-                              "chap=<user>/<password> or nochap")
+                              "chap=<user>/<password> [chap_mutual]=<user>/<password> or nochap")
             return
 
         if chap == 'nochap':
@@ -340,12 +366,22 @@ class Client(UINode):
                     "supported characters")
                 return
 
-        self.logger.debug(
-            "CHAP to be set to '{}' for '{}'".format(chap, self.client_iqn))
+        if not chap_mutual:
+            chap_mutual = ''
+        else:
+            if '/' not in chap_mutual:
+                self.logger.error(
+                    "CHAP_MUTUAL format is invalid - must be a <username>/<password> "
+                    "format. Use 'help auth' to show the correct syntax and "
+                    "supported characters")
+                return
+
+        self.logger.debug("auth to be set to chap='{}', chap_mutual='{}' for '{}'".format(
+            chap, chap_mutual, self.client_iqn))
 
         target_iqn = self.parent.parent.name
 
-        api_vars = {"chap": chap}
+        api_vars = {"chap": chap, "chap_mutual": chap_mutual}
 
         clientauth_api = ('{}://localhost:{}/api/'
                           'clientauth/{}/{}'.format(self.http_mode,
@@ -362,6 +398,10 @@ class Client(UINode):
                 self.auth['chap'] = chap
             else:
                 self.auth['chap'] = "None"
+            if chap_mutual != '':
+                self.auth['chap_mutual'] = chap_mutual
+            else:
+                self.auth['chap_mutual'] = "None"
 
             self.logger.info('ok')
 
@@ -371,13 +411,13 @@ class Client(UINode):
                                                              self.logger)))
             return
 
-    def ui_command_auth(self, chap=None):
+    def ui_command_auth(self, chap=None, chap_mutual=None):
         """
-        Client authentication can be set to use CHAP by supplying the
-        a string of the form <username>/<password>
+        Client authentication can be set to use CHAP/CHAP_MUTUAL by supplying
+        strings of the form <username>/<password>
 
         e.g.
-        auth chap=username/password
+        auth chap=username/password chap_mutual=username/password
 
         username ... the username is 8-64 character string. Each character
                      may either be an alphanumeric or use one of the following
@@ -402,7 +442,7 @@ class Client(UINode):
 
         if not chap:
             self.logger.error("To set authentication, specify "
-                              "chap=<user>/<password>")
+                              "chap=<user>/<password> [chap_mutual]=<user>/<password>")
             return
 
         if chap == 'nochap':
@@ -411,7 +451,7 @@ class Client(UINode):
                               "the hosts node within gwcli.")
             return
 
-        self.set_auth(chap)
+        self.set_auth(chap, chap_mutual)
 
     @staticmethod
     def get_srtd_names(lun_list):

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -194,7 +194,10 @@ class ISCSITargets(UIGroup):
         if api.response.status_code == 200:
             self.logger.info('ok')
             # create the target entry in the UI tree
-            Target(target_iqn, self)
+            target_exists = len([target for target in self.children
+                                 if target.name == target_iqn]) > 0
+            if not target_exists:
+                Target(target_iqn, self)
         else:
             self.logger.error("Failed to create the target on the local node")
 

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -402,6 +402,20 @@ class Disks(UIGroup):
         else:
             self.logger.error("disk name provided does not exist")
 
+    def ui_command_detach(self, image_id):
+        """
+        Delete a given rbd image from the configuration but not from ceph.
+
+        > detach <disk_name>
+        e.g.
+        > detach rbd.disk_1
+
+        "disk_name" refers to the name of the disk as shown in the UI, for
+        example rbd.disk_1.
+
+        """
+        self.delete_disk(image_id, True)
+
     def ui_command_delete(self, image_id):
         """
         Delete a given rbd image from the configuration and ceph. This is a
@@ -419,6 +433,9 @@ class Disks(UIGroup):
         the rbd image is, the longer the delete will take to run.
 
         """
+        self.delete_disk(image_id, False)
+
+    def delete_disk(self, image_id, preserve_image):
 
         # Perform a quick 'sniff' test on the request
         if image_id not in [disk.image_id for disk in self.children]:
@@ -432,7 +449,10 @@ class Disks(UIGroup):
 
         local_gw = this_host()
 
-        api_vars = {'purge_host': local_gw}
+        api_vars = {
+            'purge_host': local_gw,
+            'preserve_image': 'true' if preserve_image else 'false'
+        }
 
         disk_api = '{}://{}:{}/api/disk/{}'.format(self.http_mode,
                                                    local_gw,

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -76,7 +76,7 @@ def valid_iqn(iqn):
     return True
 
 
-def valid_gateway(gw_name, gw_ip, config):
+def valid_gateway(target_iqn, gw_name, gw_ip, config):
     """
     validate the request for a new gateway
     :param gw_name: (str) host (shortname) of the gateway
@@ -88,10 +88,11 @@ def valid_gateway(gw_name, gw_ip, config):
     http_mode = 'https' if settings.config.api_secure else "http"
 
     # if the gateway request already exists in the config, computer says "no"
-    if gw_name in config['gateways']:
+    target_config = config['targets'][target_iqn]
+    if gw_name in target_config['portals']:
         return "Gateway name {} already defined".format(gw_name)
 
-    if gw_ip in config['gateways'].get('ip_list', []):
+    if gw_ip in target_config.get('ip_list', []):
         return "IP address already defined to the configuration"
 
     # validate the gateway name is resolvable
@@ -176,8 +177,8 @@ def get_remote_gateways(config, logger):
     '''
     local_gw = this_host()
     logger.debug("this host is {}".format(local_gw))
-    gateways = [key for key in config.config['gateways']
-                if isinstance(config.config['gateways'][key], dict)]
+    gateways = [key for key in config
+                if isinstance(config[key], dict)]
     logger.debug("all gateways - {}".format(gateways))
     if local_gw not in gateways:
         raise CephiSCSIError("{} cannot be used to perform this operation "
@@ -240,9 +241,11 @@ def valid_client(**kwargs):
 
     mode = kwargs['mode']
     client_iqn = kwargs['client_iqn']
+    target_iqn = kwargs['target_iqn']
     config = get_config()
     if not config:
         return "Unable to query the local API for the current config"
+    target_config = config['targets'][target_iqn]
 
     if mode == 'create':
         # iqn must be valid
@@ -250,7 +253,7 @@ def valid_client(**kwargs):
             return ("Invalid IQN name for iSCSI")
 
         # iqn must not already exist
-        if client_iqn in config['clients']:
+        if client_iqn in target_config['clients']:
             return ("A client with the name '{}' is "
                     "already defined".format(client_iqn))
 
@@ -268,11 +271,11 @@ def valid_client(**kwargs):
     elif mode == 'delete':
 
         # client must exist in the configuration
-        if client_iqn not in config['clients']:
+        if client_iqn not in target_config['clients']:
             return ("{} is not defined yet - nothing to "
                     "delete".format(client_iqn))
 
-        this_client = config['clients'].get(client_iqn)
+        this_client = target_config['clients'].get(client_iqn)
         if this_client.get('group_name', None):
             return ("Unable to delete '{}' - it belongs to "
                     "group {}".format(client_iqn,
@@ -296,7 +299,7 @@ def valid_client(**kwargs):
     elif mode == 'auth':
         chap = kwargs['chap']
         # client iqn must exist
-        if client_iqn not in config['clients']:
+        if client_iqn not in target_config['clients']:
             return ("Client '{}' does not exist".format(client_iqn))
 
         # must provide chap as either '' or a user/password string
@@ -313,7 +316,7 @@ def valid_client(**kwargs):
 
     elif mode == 'disk':
 
-        this_client = config['clients'].get(client_iqn)
+        this_client = target_config['clients'].get(client_iqn)
         if this_client.get('group_name', None):
             return ("Unable to manage disks for '{}' - it belongs to "
                     "group {}".format(client_iqn,
@@ -324,7 +327,7 @@ def valid_client(**kwargs):
                     " a comma separated str of rbd images (pool.image)")
 
         rqst_disks = set(kwargs['image_list'].split(','))
-        mapped_disks = set(config['clients'][client_iqn]['luns'].keys())
+        mapped_disks = set(target_config['clients'][client_iqn]['luns'].keys())
         current_disks = set(config['disks'].keys())
 
         if len(rqst_disks) > len(mapped_disks):

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -167,11 +167,12 @@ def valid_gateway(target_iqn, gw_name, gw_ip, config):
     return "ok"
 
 
-def get_remote_gateways(config, logger):
+def get_remote_gateways(config, logger, local_gw_required=True):
     '''
     Return the list of remote gws.
     :param: config: Config object with gws setup.
     :param: logger: Logger object
+    :param: local_gw_required: Check if local_gw is defined within gateways configuration
     :return: A list of gw names, or CephiSCSIError if not run on a gw in the
              config
     '''
@@ -180,12 +181,12 @@ def get_remote_gateways(config, logger):
     gateways = [key for key in config
                 if isinstance(config[key], dict)]
     logger.debug("all gateways - {}".format(gateways))
-    if local_gw not in gateways:
+    if local_gw_required and local_gw not in gateways:
         raise CephiSCSIError("{} cannot be used to perform this operation "
                              "because it is not defined within the gateways "
                              "configuration".format(local_gw))
-
-    gateways.remove(local_gw)
+    if local_gw in gateways:
+        gateways.remove(local_gw)
     logger.debug("remote gateways: {}".format(gateways))
     return gateways
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -720,6 +720,11 @@ def target_disk(target_iqn=None):
                 return jsonify(message="Disk {} belongs to group "
                                        "{}".format(disk, group_name)), 400
         local_gw = this_host()
+        if local_gw not in target_config['portals']:
+            return jsonify(message="{} cannot be used to perform this operation "
+                                   "because it is not defined within target "
+                                   "gateways".format(local_gw)), 400
+
         api_vars = {
             'disk': disk,
             'purge_host': local_gw

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -571,9 +571,9 @@ def _gateway(target_iqn=None, gateway_name=None):
     :param gateway_name: (str) gateway name, normally the DNS name
     **RESTRICTED**
     """
+    target_config = config.config['targets'][target_iqn]
 
     if request.method == 'GET':
-        target_config = config.config['targets'][target_iqn]
 
         if gateway_name in target_config['portals']:
 
@@ -586,6 +586,10 @@ def _gateway(target_iqn=None, gateway_name=None):
         # the parameters need to be cast to str for compatibility
         # with the comparison logic in common.config.add_item
         logger.debug("Attempting create of gateway {}".format(gateway_name))
+
+        if gateway_name in target_config['portals']:
+            return jsonify(message="Gateway already exist in the "
+                                   "configuration"), 404
 
         gateway_ips = str(request.form['gateway_ip_list'])
         target_mode = str(request.form.get('mode', 'target'))

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -715,6 +715,10 @@ def target_disk(target_iqn=None):
             return jsonify(message="Disk {} is not defined in target "
                                    "{}".format(disk, target_iqn)), 400
 
+        for group_name, group in target_config['groups'].items():
+            if disk in group['disks']:
+                return jsonify(message="Disk {} belongs to group "
+                                       "{}".format(disk, group_name)), 400
         local_gw = this_host()
         api_vars = {
             'disk': disk,

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -836,7 +836,7 @@ def disk(image_id):
     curl --insecure --user admin:admin -d mode=create -d size=1g -d pool=rbd -d count=5
         -X PUT https://192.168.122.69:5000/api/disk/rbd.new2_
     curl --insecure --user admin:admin -d mode=create -d size=10g -d pool=rbd
-        -d controls='{max_data_area_mb=32}' -X PUT https://192.168.122.69:5000/api/disk/rbd.new3_
+        -X PUT https://192.168.122.69:5000/api/disk/rbd.new3_
     curl --insecure --user admin:admin -X GET https://192.168.122.69:5000/api/disk/rbd.new2_1
     curl --insecure --user admin:admin -X DELETE https://192.168.122.69:5000/api/disk/rbd.new2_1
     """
@@ -1007,9 +1007,6 @@ def _disk(image_id):
                 logger.error("Unable to create a LUN instance"
                              " : {}".format(lun.error_msg))
                 return jsonify(message="Unable to establish LUN instance"), 500
-
-            for k, v in controls.items():
-                setattr(lun, k, v)
 
             lun.allocate()
             if lun.error:

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -336,7 +336,7 @@ def target(target_iqn=None):
         target_config = config.config['targets'][target_iqn]
         hostnames = target_config['portals'].keys()
         if not hostnames:
-            return jsonify(message="The target must contain at least one portal"), 400
+            hostnames = [this_host()]
         resp_text, resp_code = call_api(hostnames, '_target',
                                         '{}'.format(target_iqn),
                                         http_method='delete')

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -333,8 +333,10 @@ def target(target_iqn=None):
     else:
         # DELETE target request
         config.refresh()
-        target_config = config.config['targets'][target_iqn]
-        hostnames = target_config['portals'].keys()
+        hostnames = None
+        if target_iqn in config.config['targets']:
+            target_config = config.config['targets'][target_iqn]
+            hostnames = target_config['portals'].keys()
         if not hostnames:
             hostnames = [this_host()]
         resp_text, resp_code = call_api(hostnames, '_target',

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import json
+import logging
+import sys
+import unittest
+
+import mock
+
+# We need to mock ceph libs python bindings because there's no
+# updated package in pypy
+sys.modules['rados'] = mock.Mock()
+sys.modules['rbd'] = mock.Mock()
+
+import ceph_iscsi_config.settings as settings  # noqa: E402
+from ceph_iscsi_config.common import Config  # noqa: E402
+
+
+class ChapTest(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger()
+        settings.init()
+
+    def test_upgrade_config_v4(self):
+        gateway_conf_v3 = json.dumps(self.gateway_conf_v3)
+        with mock.patch.object(Config, 'init_config', return_value=True), \
+                mock.patch.object(Config, '_read_config_object', return_value=gateway_conf_v3), \
+                mock.patch.object(Config, 'commit'):
+            config = Config(self.logger)
+            self.maxDiff = None
+            iqn = 'iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw'
+            self.assertGreater(config.config['targets'][iqn]['created'],
+                               self.gateway_conf_v4['targets'][iqn]['created'])
+            self.assertGreater(config.config['targets'][iqn]['updated'],
+                               self.gateway_conf_v4['targets'][iqn]['updated'])
+            config.config['targets'][iqn]['created'] = '2018/12/07 09:19:01'
+            config.config['targets'][iqn]['updated'] = '2018/12/07 09:19:02'
+            self.assertDictEqual(config.config, self.gateway_conf_v4)
+
+    gateway_conf_v3 = {
+        "clients": {
+            "iqn.1994-05.com.redhat:rh7-client": {
+                "auth": {
+                    "chap": "myiscsiusername/myiscsipassword"
+                },
+                "created": "2018/12/07 09:18:01",
+                "group_name": "mygroup",
+                "luns": {
+                    "rbd.disk_1": {
+                        "lun_id": 0
+                    }
+                },
+                "updated": "2018/12/07 09:18:02"
+            }
+        },
+        "controls": {
+            "immediate_data": False,
+            "nopin_response_timeout": 17
+        },
+        "created": "2018/12/07 09:18:03",
+        "disks": {
+            "rbd.disk_1": {
+                "controls": {
+                    "qfull_timeout": 18
+                },
+                "created": "2018/12/07 09:18:04",
+                "image": "disk_1",
+                "owner": "node1",
+                "pool": "rbd",
+                "pool_id": 7,
+                "updated": "2018/12/07 09:18:05",
+                "wwn": "4fc1071d-7e2f-4df0-95c8-925a617e2d62"
+            }
+        },
+        "epoch": 19,
+        "gateways": {
+            "created": "2018/12/07 09:18:06",
+            "ip_list": [
+                "192.168.100.201",
+                "192.168.100.202"
+            ],
+            "iqn": "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw",
+            "node1": {
+                "active_luns": 1,
+                "created": "2018/12/07 09:18:07",
+                "gateway_ip_list": [
+                    "192.168.100.201",
+                    "192.168.100.202"
+                ],
+                "inactive_portal_ips": [
+                    "192.168.100.202"
+                ],
+                "iqn": "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw",
+                "portal_ip_address": "192.168.100.201",
+                "tpgs": 2,
+                "updated": "2018/12/07 09:18:08"
+            },
+            "node2": {
+                "active_luns": 0,
+                "created": "2018/12/07 09:18:09",
+                "gateway_ip_list": [
+                    "192.168.100.201",
+                    "192.168.100.202"
+                ],
+                "inactive_portal_ips": [
+                    "192.168.100.201"
+                ],
+                "iqn": "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw",
+                "portal_ip_address": "192.168.100.202",
+                "tpgs": 2,
+                "updated": "2018/12/07 09:18:10"
+            }
+        },
+        "groups": {
+            "mygroup": {
+                "created": "2018/12/07 09:18:11",
+                "disks": {
+                    "rbd.disk_1": {
+                        "lun_id": 0
+                    }
+                },
+                "members": [
+                    "iqn.1994-05.com.redhat:rh7-client"
+                ],
+                "updated": "2018/12/07 09:18:12"
+            }
+        },
+        "updated": "2018/12/07 09:18:13",
+        "version": 3
+    }
+
+    gateway_conf_v4 = {
+        "created": "2018/12/07 09:18:03",
+        "disks": {
+            "rbd.disk_1": {
+                "controls": {
+                    "qfull_timeout": 18
+                },
+                "created": "2018/12/07 09:18:04",
+                "image": "disk_1",
+                "owner": "node1",
+                "pool": "rbd",
+                "pool_id": 7,
+                "updated": "2018/12/07 09:18:05",
+                "wwn": "4fc1071d-7e2f-4df0-95c8-925a617e2d62"
+            }
+        },
+        "epoch": 19,
+        "gateways": {
+            "node1": {
+                "active_luns": 1,
+                "created": "2018/12/07 09:18:07",
+                "updated": "2018/12/07 09:18:08"
+            },
+            "node2": {
+                "active_luns": 0,
+                "created": "2018/12/07 09:18:09",
+                "updated": "2018/12/07 09:18:10"
+            }
+        },
+        "targets": {
+            "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw": {
+                "clients": {
+                    "iqn.1994-05.com.redhat:rh7-client": {
+                        "auth": {
+                            "chap": "myiscsiusername/myiscsipassword"
+                        },
+                        "group_name": "mygroup",
+                        "luns": {
+                            "rbd.disk_1": {
+                                "lun_id": 0
+                            }
+                        }
+                    }
+                },
+                "controls": {
+                    "immediate_data": False,
+                    "nopin_response_timeout": 17
+                },
+                "created": "2018/12/07 09:19:01",
+                "disks": [
+                    "rbd.disk_1"
+                ],
+                "groups": {
+                    "mygroup": {
+                        "disks": {
+                            "rbd.disk_1": {
+                                "lun_id": 0
+                            }
+                        },
+                        "members": [
+                            "iqn.1994-05.com.redhat:rh7-client"
+                        ]
+                    }
+                },
+                "ip_list": [
+                    "192.168.100.201",
+                    "192.168.100.202"
+                ],
+                "portals": {
+                    "node1": {
+                        "gateway_ip_list": [
+                            "192.168.100.201",
+                            "192.168.100.202"
+                        ],
+                        "inactive_portal_ips": [
+                            "192.168.100.202"
+                        ],
+                        "portal_ip_address": "192.168.100.201",
+                        "tpgs": 2
+                    },
+                    "node2": {
+                        "gateway_ip_list": [
+                            "192.168.100.201",
+                            "192.168.100.202"
+                        ],
+                        "inactive_portal_ips": [
+                            "192.168.100.201"
+                        ],
+                        "portal_ip_address": "192.168.100.202",
+                        "tpgs": 2
+                    }
+                },
+                "updated": "2018/12/07 09:19:02"
+            }
+        },
+        "updated": "2018/12/07 09:18:13",
+        "version": 4
+    }

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -165,7 +165,8 @@ class ChapTest(unittest.TestCase):
                 "clients": {
                     "iqn.1994-05.com.redhat:rh7-client": {
                         "auth": {
-                            "chap": "myiscsiusername/myiscsipassword"
+                            "chap": "myiscsiusername/myiscsipassword",
+                            "chap_mutual": ""
                         },
                         "group_name": "mygroup",
                         "luns": {

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -147,6 +147,10 @@ class ChapTest(unittest.TestCase):
                 "wwn": "4fc1071d-7e2f-4df0-95c8-925a617e2d62"
             }
         },
+        "discovery_auth": {
+            "chap": "",
+            "chap_mutual": ""
+        },
         "epoch": 19,
         "gateways": {
             "node1": {

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -140,6 +140,7 @@ class ChapTest(unittest.TestCase):
                 },
                 "created": "2018/12/07 09:18:04",
                 "image": "disk_1",
+                "allocating_host": "node1",
                 "owner": "node1",
                 "pool": "rbd",
                 "pool_id": 7,

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -140,7 +140,6 @@ class ChapTest(unittest.TestCase):
                 },
                 "created": "2018/12/07 09:18:04",
                 "image": "disk_1",
-                "allocating_host": "node1",
                 "owner": "node1",
                 "pool": "rbd",
                 "pool_id": 7,


### PR DESCRIPTION
This PR adds support for multiple iSCSI targets.

![screenshot from 2018-12-10 14-48-50](https://user-images.githubusercontent.com/14297426/49739911-ee63bb80-fc8a-11e8-9a77-1ae43646a27d.png)

**Some other changes included in this PR:**

- Add `detach <disk>` command
      (similar to `delete <disk>` but will not delete the RBD image)

- Add `attach <disk>` command
      (similar to `create <disk>` but will not create the RBD image)

- Lazy creation of LIO storage objects
      (LIO storage objects will only be created when mapped to a target)

- Allow disk deletion from a `gwcli` running on any host
      (instead of forcing the user to connect to the disk allocating host)

- Mutual chap authentication

- Discovery authentication (chap and chap_mutual)