### PR TITLE
Disk size is optional if image already exists

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -834,13 +834,13 @@ class LUN(GWObject):
 
         if mode in ['create', 'resize']:
 
-            if not valid_size(kwargs['size']):
-                return "Size is invalid"
-
-            elif kwargs['pool'] not in get_pools():
+            if kwargs['pool'] not in get_pools():
                 return "pool name is invalid"
 
         if mode == 'create':
+            if kwargs['size'] and not valid_size(kwargs['size']):
+                return "Size is invalid"
+
             if len(config['disks']) >= 256:
                 return "Disk limit of 256 reached."
 
@@ -882,6 +882,9 @@ class LUN(GWObject):
                                                kwargs['image']))
 
         if mode == 'resize':
+
+            if not valid_size(kwargs['size']):
+                return "Size is invalid"
 
             size = kwargs['size'].upper()
             current_size = get_rbd_size(kwargs['pool'], kwargs['image'])

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -475,10 +475,6 @@ class Client(UINode):
             if action == 'add':
                 ui_root = self.get_ui_root()
                 ui_disks = ui_root.disks
-                if not size:
-                    self.logger.error("To auto-define the disk to the client"
-                                      " you must provide a disk size")
-                    return
 
                 # a disk given here would be of the form pool.image
                 pool, image = disk.split('.')

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -202,20 +202,16 @@ class Disks(UIGroup):
                                           "({} ?)".format(size))
                         return
                 size = image
-            else:
-                self.logger.error("Shorthand command is create <pool>.<image>"
-                                  " <size>")
-                return
             pool, image = pool.split('.')
 
         else:
             # long format request
-            if not pool or not image or not size:
-                self.logger.error("Invalid create: pool, image and size "
+            if not pool or not image:
+                self.logger.error("Invalid create: pool and image "
                                   "parameters are needed")
                 return
 
-        if not valid_size(size):
+        if size and not valid_size(size):
             self.logger.error("Invalid size requested. Must be an integer, "
                               "suffixed by M, G or T. See help for more info")
             return
@@ -294,8 +290,10 @@ class Disks(UIGroup):
 
         controls_json = json.dumps(controls)
 
-        api_vars = {'pool': pool, 'size': size.upper(), 'owner': local_gw,
+        api_vars = {'pool': pool, 'owner': local_gw,
                     'count': count, 'controls': controls_json, 'mode': 'create'}
+        if size:
+            api_vars['size'] = size.upper()
 
         self.logger.debug("Issuing disk create request")
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -718,6 +718,13 @@ def disk(image_id):
         if disk_usable != 'ok':
             return jsonify(message=disk_usable), 400
 
+        if not size:
+            try:
+                rbd_image = RBDDev(image_name, 0, pool)
+                size = rbd_image.current_size
+            except rbd.ImageNotFound:
+                return jsonify(message="Size parameter is required when creating a new image"), 400
+
         if mode == 'reconfigure':
             resp_text, resp_code = lun_reconfigure(image_id, controls)
             if resp_code == 200:


### PR DESCRIPTION
User should be able to create a disk using an existing RBD image, but in this case, it doesn't make sense to force the user to specify the disk size.

This PR will make the `size` parameter optional when image already exists.

Note that in Ceph Manager Dashboard we will use images that were previously created on the dedicated `Block > Images` page.


Signed-off-by: Ricardo Marques <rimarques@suse.com>