### PR TITLE
Fix restart of rbd-target-gw service

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -231,7 +231,7 @@ class GWClient(GWObject):
             client_metadata = config.config['clients'][client_iqn]
             client_chap = CHAP(client_metadata['auth']['chap'])
 
-            image_list = client_metadata['luns'].keys()
+            image_list = list(client_metadata['luns'].keys())
 
             chap_str = client_chap.chap_str
             if client_chap.error:


### PR DESCRIPTION
The keys() returns a dict_keys and not a list.  The GWClient.__init__
throws a Type Error on isinstance(image_list[0],...).  This prevents the
service from starting.

Signed-off-by: Eric Jackson <swiftgist@gmail.com>