### PR TITLE
Use normalized iscsi names

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -46,7 +46,6 @@ class GWClient(GWObject):
         :return:
         """
 
-        self.iqn = client_iqn
         self.target_iqn = target_iqn
         self.lun_lookup = {}        # only used for hostgroup based definitions
         self.requested_images = []
@@ -87,10 +86,12 @@ class GWClient(GWObject):
         self.error_msg = ''
 
         try:
-            normalize_wwn(['iqn'], client_iqn)
+            client_iqn, iqn_type = normalize_wwn(['iqn'], client_iqn)
         except RTSLibError as err:
             self.error = True
-            self.error_msg = "Invalid client name for iSCSI - {}".format(err)
+            self.error_msg = "Invalid iSCSI client name - {}".format(err)
+
+        self.iqn = client_iqn
 
         # Validate the images list doesn't contain duplicate entries
         dup_images = set([rbd for rbd in image_list

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -5,7 +5,7 @@ import os
 from rtslib_fb.target import Target, TPG, NetworkPortal, LUN
 from rtslib_fb.fabric import ISCSIFabricModule
 from rtslib_fb import root
-from rtslib_fb.utils import RTSLibError
+from rtslib_fb.utils import RTSLibError, normalize_wwn
 from rtslib_fb.alua import ALUATargetPortGroup
 
 import ceph_iscsi_config.settings as settings
@@ -56,6 +56,11 @@ class GWTarget(GWObject):
         self.enable_portal = enable_portal  # boolean to trigger portal IP creation
         self.logger = logger                # logger object
 
+        try:
+            iqn, iqn_type = normalize_wwn(['iqn'], iqn)
+        except RTSLibError as err:
+            self.error = True
+            self.error_msg = "Invalid iSCSI target name - {}".format(err)
         self.iqn = iqn
 
         # Ensure IPv6 addresses are in the normalized address (not literal) format

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -2,13 +2,14 @@
 
 from gwcli.node import UIGroup, UINode
 
-from gwcli.utils import response_message, valid_iqn, APIRequest
+from gwcli.utils import response_message, APIRequest
 
 from ceph_iscsi_config.client import CHAP
 import ceph_iscsi_config.settings as settings
 from ceph_iscsi_config.utils import human_size
 
 import rtslib_fb.root as root
+from rtslib_fb.utils import normalize_wwn, RTSLibError
 
 # this ignores the warning issued when verify=False is used
 from requests.packages import urllib3
@@ -64,7 +65,9 @@ class Clients(UIGroup):
         cli_seed = {"luns": {}, "auth": {}}
 
         # is the IQN usable?
-        if not valid_iqn(client_iqn):
+        try:
+            client_iqn, iqn_type = normalize_wwn(['iqn'], client_iqn)
+        except RTSLibError:
             self.logger.error("IQN name '{}' is not valid for "
                               "iSCSI".format(client_iqn))
             return
@@ -112,7 +115,9 @@ class Clients(UIGroup):
         self.logger.debug("Client DELETE for {}".format(client_iqn))
 
         # is the IQN usable?
-        if not valid_iqn(client_iqn):
+        try:
+            client_iqn, iqn_type = normalize_wwn(['iqn'], client_iqn)
+        except RTSLibError:
             self.logger.error("IQN name '{}' is not valid for "
                               "iSCSI".format(client_iqn))
             return

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -61,21 +61,6 @@ def get_config():
     return {}
 
 
-def valid_iqn(iqn):
-    """
-    confirm whether the given iqn is in an acceptable format
-    :param iqn: (str) iqn name to check
-    :return: (bool) True if iqn is valid for iSCSI
-    """
-
-    try:
-        normalize_wwn(['iqn'], iqn)
-    except RTSLibError:
-        return False
-
-    return True
-
-
 def valid_gateway(target_iqn, gw_name, gw_ip, config):
     """
     validate the request for a new gateway
@@ -250,7 +235,9 @@ def valid_client(**kwargs):
 
     if mode == 'create':
         # iqn must be valid
-        if not valid_iqn(client_iqn):
+        try:
+            normalize_wwn(['iqn'], client_iqn)
+        except RTSLibError:
             return ("Invalid IQN name for iSCSI")
 
         # iqn must not already exist

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -247,6 +247,12 @@ def target(target_iqn=None):
         -X PUT http://192.168.122.69:5000/api/target/iqn.2003-01.com.redhat.iscsi-gw0
     """
 
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
     if request.method == 'PUT':
         mode = request.form.get('mode', None)
         if mode not in [None, 'reconfigure']:
@@ -482,6 +488,12 @@ def gateways(target_iqn=None):
         http://192.168.122.69:5000/api/gateways/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
     """
 
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
     target_config = config.config['targets'][target_iqn]
     if request.method == 'GET':
         return jsonify(target_config['portals']), 200
@@ -510,6 +522,12 @@ def gateway(target_iqn=None, gateway_name=None):
     # running config to the new host. The downside is that this sync task
     # could take a while if there are 100's of disks/clients. Future work should
     # aim to make this synchronisation of the new gateway an async task
+
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
 
     ip_address = request.form.get('ip_address')
     nosync = request.form.get('nosync', 'false')
@@ -669,6 +687,12 @@ def target_disk(target_iqn=None):
     curl --insecure --user admin:admin -d disk=rbd.new2_1
         -X PUT https://192.168.122.69:5000/api/targetlun/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
     """
+
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
 
     target_config = config.config['targets'][target_iqn]
 
@@ -1453,6 +1477,12 @@ def get_clients(target_iqn=None):
         https://192.168.122.69:5000/api/clients/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
     """
 
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
     target_config = config.config['targets'][target_iqn]
     client_list = target_config['clients'].keys()
     response = {"clients": client_list}
@@ -1518,6 +1548,18 @@ def clientauth(target_iqn, client_iqn):
     curl --insecure --user admin:admin -d chap=dmin1234/admin12345678
         -X PUT https://192.168.122.69:5000/api/clientauth/iqn.2017-08.org.ceph:iscsi-gw0
     """
+
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
+    try:
+        client_iqn, iqn_type = normalize_wwn(['iqn'], client_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(client_iqn, err)
+        return jsonify(message=err_str), 500
 
     # http_mode = 'https' if settings.config.api_secure else 'http'
     target_config = config.config['targets'][target_iqn]
@@ -1594,6 +1636,18 @@ def clientlun(target_iqn, client_iqn):
     curl --insecure --user admin:admin -d disk=rbd.new2_1
         -X PUT https://192.168.122.69:5000/api/clientlun/iqn.2017-08.org.ceph:iscsi-gw0
     """
+
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
+    try:
+        client_iqn, iqn_type = normalize_wwn(['iqn'], client_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(client_iqn, err)
+        return jsonify(message=err_str), 500
 
     # http_mode = 'https' if settings.config.api_secure else 'http'
     target_config = config.config['targets'][target_iqn]
@@ -1701,6 +1755,18 @@ def client(target_iqn, client_iqn):
 
     method = {"PUT": 'create',
               "DELETE": 'delete'}
+
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
+    try:
+        client_iqn, iqn_type = normalize_wwn(['iqn'], client_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(client_iqn, err)
+        return jsonify(message=err_str), 500
 
     # http_mode = 'https' if settings.config.api_secure else 'http'
     target_config = config.config['targets'][target_iqn]
@@ -1827,6 +1893,12 @@ def hostgroups(target_iqn=None):
         http://192.168.122.69:5000/api/hostgroups/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
     """
 
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
+
     target_config = config.config['targets'][target_iqn]
     if request.method == 'GET':
         return jsonify({"groups": target_config['groups'].keys()}), 200
@@ -1854,6 +1926,12 @@ def hostgroup(target_iqn, group_name):
     """
     http_mode = 'https' if settings.config.api_secure else 'http'
     valid_hostgroup_actions = ['add', 'remove']
+
+    try:
+        target_iqn, iqn_type = normalize_wwn(['iqn'], target_iqn)
+    except RTSLibError as err:
+        err_str = "Invalid iqn {} - {}".format(target_iqn, err)
+        return jsonify(message=err_str), 500
 
     target_config = config.config['targets'][target_iqn]
     try:


### PR DESCRIPTION
The iSCSI spec defines the initiator/target names as case insensitive and rtslib will convert capital letters to lower case. If the user passes in upper case we will store that non-normalized format in gateway.conf then later try to match that with the rtslib/kernel value. So we can end up creating clients/targets with capital letters but not remove them.

This patch series has us normalize and use that name at the gwcli/user level, API layer and lib/ceph-iscsi-config layers, so if it is user input or an app creating these objects we will always use the value rtslib and the kernel uses.