### PR TITLE
Fix race condition on gateway creation

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -517,6 +517,7 @@ def gateway(target_iqn=None, gateway_name=None):
 
     # first confirm that the request is actually valid, if not return a 400
     # error with the error description
+    config.refresh()
     current_config = config.config
 
     if skipchecks.lower() == 'true':


### PR DESCRIPTION
After a sequence of multiple REST Api calls to create gateways, I ended up with an inconsistent `ip_list` in the configuration:

**How to reproduce:**

1) API call to create gateway **node1 192.182.100.201**
2) API call to create gateway **node2 192.182.100.202**
3) API call to create gateway **node3 192.182.100.203**

Looking into the configuration we can see that `192.182.100.202` is missing in the `ip_list`, but `node2` was added:
```
...
targets": {
        "iqn.2003-01.com.redhat.iscsi.gw:1547740766118": {
            "ip_list": [
                "192.168.100.201",
                "192.168.100.203"
            ],
            "portals": {
                "node1": {...},
                "node2": {...},
                "node3": {...},
...
```

This is caused by a missing `config.refresh()`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>