### PR TITLE
Fix race condition on group deletion

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2110,6 +2110,7 @@ def _hostgroup(target_iqn, group_name):
         grp = Group(logger, target_iqn, group_name)
         grp.purge()
         if not grp.error:
+            config.refresh()
             return jsonify(message="Group '{}' removed".format(group_name)), 200
         else:
             return jsonify(message=grp.error_msg), 400


### PR DESCRIPTION
This PR adds a missing `config.refresh()` after group deletion.

Signed-off-by: Ricardo Marques <rimarques@suse.com>