### PR TITLE
Config API should always attempt a config refresh

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -474,6 +474,7 @@ def get_config():
     """
 
     if request.method == 'GET':
+        config.refresh()
         return jsonify(config.config), 200
 
 


### PR DESCRIPTION
This will ensure that the returned config is always up-to-date regardless of where changes were made.

Signed-off-by: Ricardo Marques <rimarques@suse.com>