### PR TITLE
Fix race condition after target creation

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -599,6 +599,7 @@ def _gateway(target_iqn=None, gateway_name=None):
     :param gateway_name: (str) gateway name, normally the DNS name
     **RESTRICTED**
     """
+    config.refresh()
     target_config = config.config['targets'][target_iqn]
 
     if request.method == 'GET':


### PR DESCRIPTION
How to reproduce (starting with a clean configuration):

1. API call to create target on node1
2. API call to create gateway node1 192.182.100.201
3. API call to create gateway node2 192.182.100.202

Sometimes it fails on step `3` because the newly created target doesn't exist in the node2 config yet

Signed-off-by: Ricardo Marques <rimarques@suse.com>