### PR TITLE
Disk is a required param when adding/deleting targetlun

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -201,7 +201,7 @@ class RBDDev(object):
 
                 if rbd_image.features() & RBDDev.required_features() != \
                         RBDDev.required_features():
-                        valid_state = False
+                    valid_state = False
 
         return valid_state
 

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -945,7 +945,7 @@ class TargetDisks(UIGroup):
         for disk in disks:
             TargetDisk(self, disk)
 
-    def ui_command_add(self, disk=None):
+    def ui_command_add(self, disk):
         self.add_disk(disk)
 
     def add_disk(self, disk, success_msg='ok'):
@@ -975,7 +975,7 @@ class TargetDisks(UIGroup):
             rc = 1
         return rc
 
-    def ui_command_delete(self, disk=None):
+    def ui_command_delete(self, disk):
         self.delete_disk(disk)
 
     def delete_disk(self, disk):

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -322,7 +322,7 @@ def apply_config():
         try:
             LUN.define_luns(logger, config, gateway)
         except CephiSCSIError as err:
-                halt("{} - Could not define LUNs: {}".format(gateway.iqn, err))
+            halt("{} - Could not define LUNs: {}".format(gateway.iqn, err))
 
         logger.info("{} - Processing client configuration".format(gateway.iqn))
         try:


### PR DESCRIPTION
This will guarantee that `/iscsi-targets/<target>/disks` `help` command will provide the correct information about the `disk` param, and an appropriate message will be displayed if the user execute `add` or `delete` command without specifying the disk.

Signed-off-by: Ricardo Marques <rimarques@suse.com>