### PR TITLE
packaging: Move python unbuffered option to systemd unit file

### DIFF
--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python -u
-# NB the python environment is using unbuffered mode (-u), so any "print"
-# statements will appear in the syslog 'immediately'
+#!/usr/bin/python
 
 import signal
 import logging

--- a/usr/lib/systemd/system/rbd-target-gw.service
+++ b/usr/lib/systemd/system/rbd-target-gw.service
@@ -8,6 +8,7 @@ Wants=network-online.target tcmu-runner.service
 [Service]
 LimitNOFILE=1048576
 LimitNPROC=1048576
+Environment=PYTHONUNBUFFERED=TRUE
 EnvironmentFile=-/etc/sysconfig/ceph
 Type=simple
 User=root


### PR DESCRIPTION
This change is required to avoid a problem originated when running
setuptools with the --executable option to override the shebang
of the pyhton script when the original file has a shebang with a
parameter.
Example:
  original file has:

Running python setup.py --executable=/usr/bin/pyhton -s will generate
an executable file with:

which is not a valid shebang.

Signed-off-by: Ricardo Dias <rdias@suse.com>