### PR TITLE
Adds infrastructure for multiple backstores

### DIFF
--- a/ceph_iscsi_config/backstore.py
+++ b/ceph_iscsi_config/backstore.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+
+USER_RBD = 'user:rbd'

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -5,6 +5,7 @@ import time
 import json
 import traceback
 
+from ceph_iscsi_config.backstore import USER_RBD
 import ceph_iscsi_config.settings as settings
 from ceph_iscsi_config.utils import get_time
 
@@ -54,7 +55,7 @@ class Config(object):
                    "targets": {},
                    "discovery_auth": {'chap': '',
                                       'chap_mutual': ''},
-                   "version": 4,
+                   "version": 5,
                    "epoch": 0,
                    "created": '',
                    "updated": ''
@@ -211,6 +212,12 @@ class Config(object):
             self.del_item('groups', None)
             self.update_item("gateways", None, gateways)
             self.update_item("version", None, 4)
+
+        if self.config['version'] == 4:
+            for disk_id, disk in self.config['disks'].items():
+                disk['backstore'] = USER_RBD
+                self.update_item("disks", disk_id, disk)
+            self.update_item("version", None, 5)
 
         self.commit("retain")
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -23,23 +23,31 @@ class ChapTest(unittest.TestCase):
         self.logger = logging.getLogger()
         settings.init()
 
-    def test_upgrade_config_v4(self):
-        gateway_conf_v3 = json.dumps(self.gateway_conf_v3)
+    def test_upgrade_config(self):
+        gateway_conf_initial = json.dumps(self.gateway_conf_initial)
         with mock.patch.object(Config, 'init_config', return_value=True), \
-                mock.patch.object(Config, '_read_config_object', return_value=gateway_conf_v3), \
+                mock.patch.object(Config, '_read_config_object',
+                                  return_value=gateway_conf_initial), \
                 mock.patch.object(Config, 'commit'):
             config = Config(self.logger)
             self.maxDiff = None
+
             iqn = 'iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw'
             self.assertGreater(config.config['targets'][iqn]['created'],
-                               self.gateway_conf_v4['targets'][iqn]['created'])
+                               self.gateway_conf_latest['targets'][iqn]['created'])
             self.assertGreater(config.config['targets'][iqn]['updated'],
-                               self.gateway_conf_v4['targets'][iqn]['updated'])
+                               self.gateway_conf_latest['targets'][iqn]['updated'])
             config.config['targets'][iqn]['created'] = '2018/12/07 09:19:01'
             config.config['targets'][iqn]['updated'] = '2018/12/07 09:19:02'
-            self.assertDictEqual(config.config, self.gateway_conf_v4)
 
-    gateway_conf_v3 = {
+            disk = 'rbd.disk_1'
+            self.assertGreater(config.config['disks'][disk]['updated'],
+                               self.gateway_conf_latest['disks'][disk]['updated'])
+            config.config['disks'][disk]['updated'] = '2018/12/07 09:19:03'
+
+            self.assertDictEqual(config.config, self.gateway_conf_latest)
+
+    gateway_conf_initial = {
         "clients": {
             "iqn.1994-05.com.redhat:rh7-client": {
                 "auth": {
@@ -131,7 +139,7 @@ class ChapTest(unittest.TestCase):
         "version": 3
     }
 
-    gateway_conf_v4 = {
+    gateway_conf_latest = {
         "created": "2018/12/07 09:18:03",
         "disks": {
             "rbd.disk_1": {
@@ -141,9 +149,10 @@ class ChapTest(unittest.TestCase):
                 "created": "2018/12/07 09:18:04",
                 "image": "disk_1",
                 "owner": "node1",
+                "backstore": "user:rbd",
                 "pool": "rbd",
                 "pool_id": 7,
-                "updated": "2018/12/07 09:18:05",
+                "updated": "2018/12/07 09:19:03",
                 "wwn": "4fc1071d-7e2f-4df0-95c8-925a617e2d62"
             }
         },
@@ -232,5 +241,5 @@ class ChapTest(unittest.TestCase):
             }
         },
         "updated": "2018/12/07 09:18:13",
-        "version": 4
+        "version": 5
     }


### PR DESCRIPTION
**Motivation**
In _openSUSE_, we have 2 different "backstores" so we have to patch `ceph-iscsi` in order to support the `kernel-lio-rbd` in addition to the already supported `tcmu-runner`.

**Proposed Solution**
With this PR, `ceph-iscsi` will continue to only support `tcmu-runner` but the code (and `gateway.conf`) will be prepared to easily add support for a different backstore.
This proposed change will not only simplify the _openSUSE_ patch, but also be useful if, in the future, `ceph-iscsi` has to support any additional backstore.

Signed-off-by: Ricardo Marques <rimarques@suse.com>