### PR TITLE
Adds support for disabling ACL authentication

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -276,7 +276,7 @@ class GWClient(GWObject):
 
         tpg.set_attribute('authentication', '0')
 
-    def configure_auth(self, chap_credentials, chap_mutual_credentials):
+    def configure_auth(self, chap_credentials, chap_mutual_credentials, target_config):
         """
         Attempt to configure authentication for the client
         :return:
@@ -361,6 +361,15 @@ class GWClient(GWObject):
                               "credentials for {}".format(self.iqn))
         else:
             self.change_count += 1
+
+        self._update_acl(target_config)
+
+    def _update_acl(self, target_config):
+        if self.tpg.node_acls:
+            self.tpg.set_attribute('generate_node_acls', 0)
+            if not target_config['acl_enabled']:
+                target_config['acl_enabled'] = True
+                self.change_count += 1
 
     def _add_lun(self, image, lun):
         """
@@ -573,7 +582,7 @@ class GWClient(GWObject):
                 self.logger.warning("(main) client '{}' configured without"
                                     " security".format(self.iqn))
 
-            self.configure_auth(self.chap, self.chap_mutual)
+            self.configure_auth(self.chap, self.chap_mutual, target_config)
             if self.error:
                 return
 

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -55,7 +55,7 @@ class Config(object):
                    "targets": {},
                    "discovery_auth": {'chap': '',
                                       'chap_mutual': ''},
-                   "version": 5,
+                   "version": 6,
                    "epoch": 0,
                    "created": '',
                    "updated": ''
@@ -218,6 +218,12 @@ class Config(object):
                 disk['backstore'] = USER_RBD
                 self.update_item("disks", disk_id, disk)
             self.update_item("version", None, 5)
+
+        if self.config['version'] == 5:
+            for target_iqn, target in self.config['targets'].items():
+                target['acl_enabled'] = True
+                self.update_item("targets", target_iqn, target)
+            self.update_item("version", None, 6)
 
         self.commit("retain")
 

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -231,6 +231,14 @@ class GWTarget(GWObject):
             self.error = True
             self.error_msg = "Unable to delete target - {}".format(err)
 
+    def update_acl(self, config):
+        target_config = config.config["targets"][self.iqn]
+        for tpg in self.tpg_list:
+            if target_config['acl_enabled']:
+                tpg.set_attribute('generate_node_acls', 0)
+            else:
+                tpg.set_attribute('generate_node_acls', 1)
+
     def create_tpg(self, ip):
 
         try:
@@ -550,6 +558,8 @@ class GWTarget(GWObject):
 
                 self.map_luns(config)
 
+                self.update_acl(config)
+
             else:
                 self.error = True
                 self.error_msg = ("Attempted to map to a gateway '{}' that "
@@ -570,6 +580,7 @@ class GWTarget(GWObject):
                 seed_target = {
                     'disks': [],
                     'clients': {},
+                    'acl_enabled': True,
                     'portals': {},
                     'groups': {},
                     'controls': {}

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -1486,6 +1486,79 @@ def _discoveryauth():
     return jsonify(message='OK'), 200
 
 
+@app.route('/api/targetauth/<target_iqn>', methods=['PUT'])
+@requires_restricted_auth
+def targetauth(target_iqn=None):
+    """
+    Coordinate the gen-acls across each gateway node
+    :param target_iqn: (str) IQN of the target
+    :param action: (str) action to be performed
+    **RESTRICTED**
+    Examples:
+    curl --insecure --user admin:admin -d auth='disable_acl'
+        -X PUT https://192.168.122.69:5000/api/targetauth/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
+    """
+
+    action = request.form.get('action')
+    if action not in ['disable_acl', 'enable_acl']:
+        return jsonify(message='Invalid auth {}'.format(action)), 400
+
+    target_config = config.config['targets'][target_iqn]
+
+    if action == 'disable_acl' and target_config['clients'].keys():
+        return jsonify(message='Cannot disable ACL authentication '
+                               'because target has clients'), 400
+
+    try:
+        gateways = get_remote_gateways(target_config['portals'], logger)
+    except CephiSCSIError as err:
+        return jsonify(message="{}".format(err)), 400
+    local_gw = this_host()
+    gateways.insert(0, local_gw)
+
+    # Apply to all gateways
+    api_vars = {
+        "committing_host": local_gw,
+        "action": action
+    }
+    resp_text, resp_code = call_api(gateways, '_targetauth',
+                                    target_iqn,
+                                    http_method='put',
+                                    api_vars=api_vars)
+
+    return jsonify(message="target auth {} - {}".format(action, resp_text)), resp_code
+
+
+@app.route('/api/_targetauth/<target_iqn>', methods=['PUT'])
+@requires_restricted_auth
+def _targetauth(target_iqn=None):
+    """
+    Apply gen-acls on the local gateway
+    Internal Use ONLY
+    **RESTRICTED**
+    """
+
+    local_gw = this_host()
+    committing_host = request.form['committing_host']
+    action = request.form['action']
+
+    target = GWTarget(logger, target_iqn, [])
+
+    target_config = config.config['targets'][target_iqn]
+    if action in ['disable_acl', 'enable_acl']:
+        target_config['acl_enabled'] = (action == 'enable_acl')
+    config.update_item('targets', target_iqn, target_config)
+
+    if target.exists():
+        target.load_config()
+        target.update_acl(config)
+
+    if committing_host == local_gw:
+        config.commit("retain")
+
+    return jsonify(message='OK'), 200
+
+
 @app.route('/api/clients/<target_iqn>', methods=['GET'])
 @requires_restricted_auth
 def get_clients(target_iqn=None):

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -189,6 +189,7 @@ class ChapTest(unittest.TestCase):
                         }
                     }
                 },
+                "acl_enabled": True,
                 "controls": {
                     "immediate_data": False,
                     "nopin_response_timeout": 17
@@ -241,5 +242,5 @@ class ChapTest(unittest.TestCase):
             }
         },
         "updated": "2018/12/07 09:18:13",
-        "version": 5
+        "version": 6
     }


### PR DESCRIPTION
Initiator name based ACL authentication can now be disabled using the `auth noacl` command (if the target doesn't contain clients).
ACL authentication will be automatically re-enabled if one client is added to the target.

Signed-off-by: Ricardo Marques <rimarques@suse.com>