### PR TITLE
Fix '_gateway' call to use names instead of IPs

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -568,12 +568,13 @@ def gateway(target_iqn=None, gateway_name=None):
     gateway_ip_list = target_config.get('ip_list', [])
 
     gateway_ip_list.append(ip_address)
-    first_gateway = (len(gateway_ip_list) == 1)
 
+    gateways = list(target_config['portals'].keys())
+    first_gateway = (len(gateways) == 0)
     if first_gateway:
         gateways = ['localhost']
     else:
-        gateways = gateway_ip_list
+        gateways.append(gateway_name)
 
     api_vars = {"gateway_ip_list": ",".join(gateway_ip_list),
                 "mode": "target",


### PR DESCRIPTION
This PR will use gateway `names` instead of portal `IPs` when calling `_gateway` endpoint, just like it's being done in other `call_api` invocations.

Using IPs instead of names may end up in an error that can be reproduced with the following steps:

1) Assume the following environment:

    - node1: 192.168.100.201 _(Flask/Api address)_
    - node2: 192.168.100.202 _(Flask/Api address)_, 192.168.121.56 _(Other address)_

2) Try to create execute the following:
```
vagrant@node1:~> sudo gwcli

/iscsi-targets> create iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
ok

/iscsi-targets> cd iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways

/iscsi-target...-igw/gateways> create node1 192.168.100.201 skipchecks=true
OS version/package checks have been bypassed
Adding gateway, sync'ing 0 disk(s) and 0 client(s)
ok

/iscsi-target...-igw/gateways> ls
o- gateways .................................................................................................. [Up: 1/1, Portals: 1]
  o- node1 .................................................................................................. [192.168.100.201 (UP)]

/iscsi-target...-igw/gateways> create node2 192.168.121.56 skipchecks=true
OS version/package checks have been bypassed
Adding gateway, sync'ing 0 disk(s) and 0 client(s)
Failed : Gateway creation failed, gateway(s) unavailable:192.168.121.56(UNKNOWN state)
```



Signed-off-by: Ricardo Marques <rimarques@suse.com>