### PR TITLE
Disk resize has no effect

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -965,7 +965,7 @@ def disk(image_id):
             return jsonify(message=disk_usable), 400
 
         create_image = request.form.get('create_image') == 'true'
-        if not create_image or not size:
+        if mode == 'create' and (not create_image or not size):
             try:
                 rbd_image = RBDDev(image_name, 0, pool)
                 size = rbd_image.current_size


### PR DESCRIPTION
This PR fixes a regression introduced during the implementation of the `attach <disk>` command, causing the ignore of the size provided by the user in the `resize <disk> <size>` command.

Signed-off-by: Ricardo Marques <rimarques@suse.com>