### PR TITLE
Optimize LUN mapping

### DIFF
--- a/ceph_iscsi_config/gateway_object.py
+++ b/ceph_iscsi_config/gateway_object.py
@@ -53,7 +53,7 @@ class GWObject(object):
                     property(lambda self, k=k: self._get_control(k),
                              lambda self, v, k=k: self._set_control(k, v)))
 
-    def commit_controls(self):
+    def update_controls(self):
         committed_controls = self._get_config_controls()
 
         if self.controls != committed_controls:
@@ -64,6 +64,8 @@ class GWObject(object):
             self.config.update_item(self.cfg_type, self.cfg_type_key,
                                     updated_obj)
 
+    def commit_controls(self):
+        self.update_controls()
         self.config.commit()
         if self.config.error:
             raise CephiSCSIError(self.config.error_msg)

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -680,7 +680,7 @@ class LUN(GWObject):
                     if self.error:
                         return
 
-                    self.commit_controls()
+                    self.update_controls()
                     self.logger.debug("(LUN.allocate) registered '{}' to LIO "
                                       "with wwn '{}' from the config "
                                       "object".format(self.image,

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -407,8 +407,6 @@ class LUN(GWObject):
             self.config.commit()
 
     def map_lun(self, target_iqn, owner, disk):
-        this_host = gethostname().split('.')[0]
-
         target_config = self.config.config['targets'][target_iqn]
         disk_metadata = self.config.config['disks'][disk]
         disk_metadata['owner'] = owner
@@ -421,10 +419,7 @@ class LUN(GWObject):
         gateway_dict['active_luns'] += 1
         self.config.update_item('gateways', owner, gateway_dict)
 
-        LUN.define_luns(self.logger, self.config, None)
-
-        if this_host == self.allocating_host:
-            self.config.commit()
+        self.allocate()
 
     def manage(self, desired_state):
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -813,10 +813,12 @@ def _target_disk(target_iqn=None):
         owner = request.form.get('owner')
         allocating_host = request.form.get('allocating_host')
 
+        rbd_image = RBDDev(image, 0, backstore, pool)
+        size = rbd_image.current_size
         lun = LUN(logger,
                   pool,
                   image,
-                  0,
+                  size,
                   allocating_host,
                   backstore)
 


### PR DESCRIPTION
According to [this conversation](https://github.com/ceph/ceph-iscsi/commit/893aada629b25032fb438dd0041e3aada31d138e#r32383227), this PR will optimize the lun mapping by executing the `LUN.allocate` method in the current lun only, instead of executing it for all luns (through the `LUN.define_luns` method).

This PR also includes one additional commit that will prevend double `config.commit` during the execution of the `LUN.allocate` method.