### PR TITLE
rpm packaging fixes

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -75,7 +75,7 @@ performance statistics, supporting monitoring and visualisation tools like
 Grafana.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 %if 0%{?with_python2}

--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -21,7 +21,7 @@ Release:        1%{?dist}
 Group:          System/Filesystems
 Summary:        Python package providing modules for ceph iscsi gateway configuration management
 
-License:        GPL-3.0-or-later
+License:        GPLv3+
 URL:            https://github.com/ceph/ceph-iscsi
 Source0:        https://github.com/ceph/ceph-iscsi/archive/%{version}/%{name}-%{version}.tar.gz
 

--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -14,6 +14,10 @@
 #
 # Please submit bugfixes or comments via http://tracker.ceph.com/
 #
+%if 0%{?rhel} == 7
+%global with_python2 1
+%endif
+
 
 Name:           ceph-iscsi
 Version:        3.0
@@ -30,6 +34,9 @@ BuildArch:      noarch
 Obsoletes:      ceph-iscsi-config
 Obsoletes:      ceph-iscsi-cli
 
+%if 0%{?with_python2}
+BuildRequires:  python2-devel
+BuildRequires:  python2-setuptools
 Requires:       python-rados >= 10.2.2
 Requires:       python-rbd >= 10.2.2
 Requires:       python-netifaces >= 0.10.4
@@ -37,9 +44,18 @@ Requires:       python-rtslib >= 2.1.fb67
 Requires:       rpm-python >= 4.11
 Requires:       python-cryptography
 Requires:       python-flask >= 0.10.1
+%else
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+Requires:       python3-rados >= 10.2.2
+Requires:       python3-rbd >= 10.2.2
+Requires:       python3-netifaces >= 0.10.4
+Requires:       python3-rtslib >= 2.1.fb67
+Requires:       python3-cryptography
+Requires:       python3-flask >= 0.10.1
+Requires:       python3-rpm >= 4.11
+%endif
 
-BuildRequires:  python-devel
-BuildRequires:  python-setuptools
 BuildRequires:  systemd
 
 %description
@@ -62,10 +78,18 @@ Grafana.
 %setup -q
 
 %build
+%if 0%{?with_python2}
 %{__python2} setup.py build
+%else
+%{py3_build}
+%endif
 
 %install
+%if 0%{?with_python2}
 %{__python2} setup.py install -O1 --skip-build --root %{buildroot}  --install-scripts %{_bindir}
+%else
+%{py3_install}
+%endif
 mkdir -p %{buildroot}%{_unitdir}
 install -m 0644 .%{_unitdir}/rbd-target-gw.service %{buildroot}%{_unitdir}
 install -m 0644 .%{_unitdir}/rbd-target-api.service %{buildroot}%{_unitdir}
@@ -88,7 +112,11 @@ gzip %{buildroot}%{_mandir}/man8/gwcli.8
 %license COPYING
 %doc README
 %doc iscsi-gateway.cfg_sample
+%if 0%{?with_python2}
 %{python2_sitelib}/*
+%else
+%{python3_sitelib}/*
+%endif
 %{_bindir}/gwcli
 %{_bindir}/rbd-target-gw
 %{_bindir}/rbd-target-api

--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -25,18 +25,18 @@ License:        GPL-3.0-or-later
 URL:            https://github.com/ceph/ceph-iscsi
 Source0:        https://github.com/ceph/ceph-iscsi/archive/%{version}/%{name}-%{version}.tar.gz
 
-BuildArch:	noarch
+BuildArch:      noarch
 
-Obsoletes:	ceph-iscsi-config
-Obsoletes:	ceph-iscsi-cli
+Obsoletes:      ceph-iscsi-config
+Obsoletes:      ceph-iscsi-cli
 
-Requires:	python-rados >= 10.2.2
-Requires:	python-rbd >= 10.2.2
-Requires:	python-netifaces >= 0.10.4
-Requires:	python-rtslib >= 2.1.fb67
-Requires:	rpm-python >= 4.11
-Requires:	python-cryptography
-Requires:	python-flask >= 0.10.1
+Requires:       python-rados >= 10.2.2
+Requires:       python-rbd >= 10.2.2
+Requires:       python-netifaces >= 0.10.4
+Requires:       python-rtslib >= 2.1.fb67
+Requires:       rpm-python >= 4.11
+Requires:       python-cryptography
+Requires:       python-flask >= 0.10.1
 
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools


### PR DESCRIPTION
Drop tabs for spaces, update the `License` to `GPLv3+`, use the `%autosetup` macro, and add Python 3 support for Fedora and RHEL 8.