### PR TITLE
Makes pool name configurable

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -63,9 +63,11 @@ class Config(object):
 
     lock_time_limit = 30
 
-    def __init__(self, logger, cfg_name='gateway.conf', pool='rbd'):
+    def __init__(self, logger, cfg_name='gateway.conf', pool=None):
         self.logger = logger
         self.config_name = cfg_name
+        if pool is None:
+            pool = settings.config.pool
         self.pool = pool
         self.ceph = None
         self.error = False

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -43,10 +43,12 @@ class RBDDev(object):
         ]
     }
 
-    def __init__(self, image, size, backstore, pool='rbd'):
+    def __init__(self, image, size, backstore, pool=None):
         self.image = image
         self.size_bytes = convert_2_bytes(size)
         self.backstore = backstore
+        if pool is None:
+            pool = settings.config.pool
         self.pool = pool
         self.pool_id = get_pool_id(pool_name=self.pool)
         self.error = False
@@ -164,7 +166,7 @@ class RBDDev(object):
         return image_size
 
     @staticmethod
-    def rbd_list(conf=None, pool='rbd'):
+    def rbd_list(conf=None, pool=None):
         """
         return a list of rbd images in a given pool
         :param pool: pool name (str) to return a list of rbd image names for
@@ -173,6 +175,8 @@ class RBDDev(object):
 
         if conf is None:
             conf = settings.config.cephconf
+        if pool is None:
+            pool = settings.config.pool
 
         with rados.Rados(conffile=conf) as cluster:
             with cluster.open_ioctx(pool) as ioctx:
@@ -1130,7 +1134,7 @@ class LUN(GWObject):
                                      "the iscsi Target")
 
 
-def rados_pool(conf=None, pool='rbd'):
+def rados_pool(conf=None, pool=None):
     """
     determine if a given pool name is defined within the ceph cluster
     :param pool: pool name to check for (str)
@@ -1139,6 +1143,8 @@ def rados_pool(conf=None, pool='rbd'):
 
     if conf is None:
         conf = settings.config.cephconf
+    if pool is None:
+        pool = settings.config.pool
 
     with rados.Rados(conffile=conf) as cluster:
         pool_list = cluster.list_pools()

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -95,6 +95,7 @@ class Settings(object):
 
     defaults = {"cluster_name": "ceph",
                 "gateway_keyring": "ceph.client.admin.keyring",
+                "pool": "rbd",
                 "time_out": 30,
                 "api_host": "::",
                 "api_port": 5000,

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -205,7 +205,7 @@ def convert_2_bytes(disk_size):
     return _bytes
 
 
-def get_pool_id(conf=None, pool_name='rbd'):
+def get_pool_id(conf=None, pool_name=None):
     """
     Query Rados to get the pool id of a given pool name
     :param conf: ceph configuration file
@@ -215,6 +215,8 @@ def get_pool_id(conf=None, pool_name='rbd'):
 
     if conf is None:
         conf = settings.config.cephconf
+    if pool_name is None:
+        pool_name = settings.config.pool
 
     with rados.Rados(conffile=conf) as cluster:
         pool_id = cluster.pool_lookup(pool_name)

--- a/iscsi-gateway.cfg_sample
+++ b/iscsi-gateway.cfg_sample
@@ -3,6 +3,9 @@
 # cluster from the gateway node is required.
 cluster_name = <ceph cluster name>
 
+# Pool name where internal `gateway.conf` object is stored
+# pool = rbd
+
 # Place a copy of the ceph cluster's admin keyring in the gateway's /etc/ceph
 # drectory and reference the filename here
 gateway_keyring = <client.admin.keyring>

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2374,7 +2374,7 @@ class ConfigWatcher(threading.Thread):
 
         cluster = rados.Rados(conffile=settings.config.cephconf)
         cluster.connect()
-        ioctx = cluster.open_ioctx('rbd')
+        ioctx = cluster.open_ioctx(settings.config.pool)
         while True:
             time.sleep(self.interval)
 


### PR DESCRIPTION
With this PR, the `pool name` used to store the `gateway.conf` can be configured in `/etc/ceph/iscsi-gateway.cfg` file (defaults to `rbd`).

Signed-off-by: Ricardo Marques <rimarques@suse.com>