### PR TITLE
Support controls with value `0`

### DIFF
--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -36,7 +36,7 @@ class Settings(object):
             if key not in settings_list:
                 raise ValueError("Supported controls: {}".format(",".join(settings_list)))
 
-            if not raw_value:
+            if raw_value in [None, '']:
                 # Use the default/reset.
                 controls[key] = None
                 continue


### PR DESCRIPTION
ATM, controls with value `0` are being ignored.

This PR adds support for `zero` value in controls.

Signed-off-by: Ricardo Marques <rimarques@suse.com>