### PR TITLE
Lun/target map and lookup fixes

### DIFF
--- a/ceph_iscsi_config/backstore.py
+++ b/ceph_iscsi_config/backstore.py
@@ -1,1 +1,13 @@
+from rtslib_fb import UserBackedStorageObject
+
+from ceph_iscsi_config.utils import CephiSCSIError
+
 USER_RBD = 'user:rbd'
+
+
+def lookup_storage_object(name, backstore):
+    if backstore == USER_RBD:
+        return UserBackedStorageObject(name=name)
+    else:
+        raise CephiSCSIError("Could not lookup storage object - "
+                             "Unsupported backstore {}".format(backstore))

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -2,7 +2,6 @@ import os
 
 from rtslib_fb.target import Target, TPG, NetworkPortal, LUN
 from rtslib_fb.fabric import ISCSIFabricModule
-from rtslib_fb import root
 from rtslib_fb.utils import RTSLibError, normalize_wwn
 from rtslib_fb.alua import ALUATargetPortGroup
 
@@ -325,10 +324,7 @@ class GWTarget(GWObject):
         """
 
         try:
-
-            lio_root = root.RTSRoot()
-            self.target = [tgt for tgt in lio_root.targets
-                           if tgt.wwn == self.iqn][0]
+            self.target = Target(ISCSIFabricModule(), self.iqn, "lookup")
 
             # clear list so we can rebuild with the current values below
             if self.tpg_list:

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -329,6 +329,10 @@ class GWTarget(GWObject):
             self.target = [tgt for tgt in lio_root.targets
                            if tgt.wwn == self.iqn][0]
 
+            # clear list so we can rebuild with the current values below
+            if self.tpg_list:
+                del self.tpg_list[:]
+
             # there could/should be multiple tpg's for the target
             for tpg in self.target.tpgs:
                 self.tpg_list.append(tpg)

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -827,19 +827,13 @@ def _target_disk(target_iqn=None):
                          "{}".format(lun.error_msg))
             return jsonify(message="Error establishing LUN instance"), 500
 
-        lun.map_lun(target_iqn, owner, disk)
-        if lun.error:
-            status_code = 400 if lun.error_msg else 500
-            logger.error("LUN add failed : {}".format(lun.error_msg))
+        try:
+            lun.map_lun(gateway, owner, disk)
+        except CephiSCSIError as err:
+            status_code = 400 if str(err) else 500
+            logger.error("LUN add failed : {}".format(err))
             return jsonify(message="Failed to add the LUN - "
-                                   "{}".format(lun.error_msg)), status_code
-
-        logger.info("Syncing TPG to LUN mapping")
-        gateway.manage('map')
-        if gateway.error:
-            return jsonify(message="Failed to sync LUNs on gateway, "
-                                   "Err {}.".format(gateway.error_msg)), 500
-
+                                   "{}".format(err)), status_code
     else:
         # DELETE gateway request
 


### PR DESCRIPTION
In a lot of cases we have been looping over lun and backstore/storage_object dirs when we did not need to. This is based off of @swimfish09's PR here:

https://github.com/ceph/ceph-iscsi/pull/17

but removes a couple extra loops.