### PR TITLE
Add support for specifying cluster client name

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -30,9 +30,7 @@ class CephCluster(object):
         self.error = False
         self.error_msg = ''
         self.cluster = rados.Rados(conffile=settings.config.cephconf,
-                                   conf=dict(keyring="{}/{}".format(
-                                             settings.config.ceph_config_dir,
-                                             settings.config.gateway_keyring)))
+                                   name=settings.config.cluster_client_name)
         try:
             self.cluster.connect()
         except rados.Error as err:

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -94,8 +94,8 @@ class Settings(object):
         return v
 
     defaults = {"cluster_name": "ceph",
-                "gateway_keyring": "ceph.client.admin.keyring",
                 "pool": "rbd",
+                "cluster_client_name": "client.admin",
                 "time_out": 30,
                 "api_host": "::",
                 "api_port": 5000,

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -160,7 +160,7 @@ class Settings(object):
                 # We always want these values set to at least the defaults.
                 self._define_settings(Settings.target_defaults)
 
-        self.cephconf = '/etc/ceph/{}.conf'.format(self.cluster_name)
+        self.cephconf = '{}/{}.conf'.format(self.ceph_config_dir, self.cluster_name)
         if self.api_secure:
             self.api_ssl_verify = False if self.api_secure else None
 

--- a/gwcli/ceph.py
+++ b/gwcli/ceph.py
@@ -1,8 +1,6 @@
 from .node import UIGroup, UINode
 import json
 import rados
-import glob
-import os
 
 from gwcli.utils import console_message, os_cmd
 import ceph_iscsi_config.settings as settings
@@ -28,70 +26,15 @@ class CephGroup(UIGroup):
                  the pool(s), together with the current over-commit percentage.
                  '''
 
-    ceph_config_dir = '/etc/ceph'
-    default_ceph_conf = '{}/ceph.conf'.format(ceph_config_dir)
-
     def __init__(self, parent):
-        UIGroup.__init__(self, 'clusters', parent)
-        self.cluster_map = self.get_clusters()
-        self.local_ceph = None
+        UIGroup.__init__(self, 'cluster', parent)
 
-        for cluster_name in self.cluster_map.keys():
-
-            cluster_client_name = None
-            if cluster_name == settings.config.cluster_name:
-
-                if settings.config.cluster_client_name:
-                    cluster_client_name = settings.config.cluster_client_name
-                    self.cluster_map[cluster_name]['client_name'] = cluster_client_name
-
-            # define the cluster object
-            self.logger.debug("Adding ceph cluster '{}' to the UI".format(cluster_name))
-            cluster = CephCluster(self,
-                                  cluster_name,
-                                  self.cluster_map[cluster_name]['conf_file'],
-                                  cluster_client_name)
-
-            self.cluster_map[cluster_name]['object'] = cluster
-            if self.cluster_map[cluster_name]['local']:
-                self.local_ceph = cluster
-
-    def get_clusters(self):
-        """
-        Look at the /etc/ceph dir to generate a dict of clusters that are
-        defined/known to the gateway
-        :return: (dict) ceph_name -> conf_file, client_name
-        """
-
-        clusters = {}       # dict ceph_name -> conf_file, client_name
-
-        conf_files = glob.glob(os.path.join(CephGroup.ceph_config_dir,
-                               '*.conf'))
-
-        valid_conf_files = [conf for conf in conf_files
-                            if CephGroup.valid_conf(conf)]
-        for conf in valid_conf_files:
-            name = os.path.basename(conf).split('.')[0]
-            keyring = glob.glob(os.path.join(CephGroup.ceph_config_dir,
-                                             '{}*.keyring'.format(name)))
-
-            client_name = None
-            if keyring:
-                keyring = keyring[0]  # select the first one
-
-                if keyring.startswith("ceph.client."):
-                    begin_idx = keyring.find(".")
-                    end_idx = keyring.find(".keyring")
-                    client_name = keyring[begin_idx + 1:end_idx]
-
-            local = True if name == settings.config.cluster_name else False
-
-            clusters[name] = {'conf_file': conf,
-                              'client_name': client_name,
-                              'name': name,
-                              'local': local}
-
-        return clusters
+        self.logger.debug("Adding ceph cluster '{}' to the UI"
+                          .format(settings.config.cluster_name))
+        self.cluster = CephCluster(self,
+                                   settings.config.cluster_name,
+                                   settings.config.cephconf,
+                                   settings.config.cluster_client_name)
 
     @staticmethod
     def valid_conf(config_file):

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -270,10 +270,7 @@ class Disks(UIGroup):
 
         # first check that the intended pool is compatible with rbd images
         root = self.get_ui_root()
-        clusters = root.ceph.cluster_map
-        local_cluster = [clusters[cluster_name] for cluster_name in clusters
-                         if clusters[cluster_name]['local']][0]['object']
-        pools = local_cluster.pools
+        pools = root.ceph.cluster.pools
         pool_object = pools.pool_lookup.get(pool, None)
         if pool_object:
             if pool_object.type == 'replicated':
@@ -360,7 +357,7 @@ class Disks(UIGroup):
                     raise GatewayAPIError("Unable to retrieve disk details "
                                           "for '{}' from the API".format(disk_key))
 
-            ceph_pools = self.parent.ceph.local_ceph.pools
+            ceph_pools = self.parent.ceph.cluster.pools
             ceph_pools.refresh()
 
         else:
@@ -538,7 +535,7 @@ class Disks(UIGroup):
                                                            self.logger)))
             return
 
-        ceph_pools = self.parent.ceph.local_ceph.pools
+        ceph_pools = self.parent.ceph.cluster.pools
         ceph_pools.refresh()
 
         self.logger.info('ok')
@@ -555,7 +552,7 @@ class Disks(UIGroup):
         ui_root = self.get_ui_root()
         state = True
         discovered_pools = [rados_pool.name for rados_pool in
-                            ui_root.ceph.local_ceph.pools.children]
+                            ui_root.ceph.cluster.pools.children]
         existing_rbds = self.disk_info.keys()
 
         storage_key = "{}/{}".format(pool, image)
@@ -653,7 +650,7 @@ class Disk(UINode):
         self.backstore_object_name = image_config['backstore_object_name']
         self.controls = {}
         self.control_values = {}
-        self.ceph_cluster = self.parent.parent.parent.ceph.local_ceph.name
+        self.ceph_cluster = self.parent.parent.parent.ceph.cluster.name
 
         disk_map = self.parent.parent.disk_info
         if image_id not in disk_map:
@@ -938,7 +935,7 @@ class Disk(UINode):
         """
         root = self.parent.parent.parent
         ceph_group = root.ceph
-        cluster = ceph_group.local_ceph
+        cluster = ceph_group.cluster
         pool = cluster.pools.pool_lookup.get(self.pool)
 
         if pool:

--- a/iscsi-gateway.cfg_sample
+++ b/iscsi-gateway.cfg_sample
@@ -6,10 +6,8 @@ cluster_name = <ceph cluster name>
 # Pool name where internal `gateway.conf` object is stored
 # pool = rbd
 
-# Place a copy of the ceph cluster's admin keyring in the gateway's /etc/ceph
-# drectory and reference the filename here
-gateway_keyring = <client.admin.keyring>
-
+# CephX client name
+# cluster_client_name = client.<rados_id>  # E.g.: client.admin
 
 # API settings.
 # The api supports a number of options that allow you to tailor it to your


### PR DESCRIPTION
Currently ceph-iscsi services will always try to connect to the cluster as `client.admin` client. This PR allows to change that.

Signed-off-by: Ricardo Dias <rdias@suse.com>