### PR TITLE
Fix lun exists check

### DIFF
--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -421,7 +421,7 @@ class GWTarget(GWObject):
                 mapped_lun = LUN(tpg, lun=lun_id, storage_object=stg_object)
                 self.changes_made = True
             except RTSLibError as err:
-                if "already exists in configFS" not in err:
+                if "already exists in configFS" not in str(err):
                     self.logger.error("LUN mapping failed: {}".format(err))
                     self.error = True
                     self.error_msg = err


### PR DESCRIPTION
We must convert exception to string before testing.

Note: In some versions of python we do not seem to have to do the
explicit conversion with a str() call and it is done automagically for
us. I am not sure what versions/why. It seems safe to always do the str() conversion.

This is probably why someone saw the exception get passed upwards as we were not matching the string comparison test.