### PR TITLE
Misc target/acl reconfigure fixes

### DIFF
--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -480,7 +480,7 @@ class Target(UINode):
         config = self.parent.parent._get_config()
         if not config:
             self.logger.error("Unable to refresh local config")
-        self.controls = config.get('controls', {})
+        self.controls = config['targets'][self.target_iqn]['controls']
 
         self.logger.info('ok')
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -271,6 +271,16 @@ def target(target_iqn=None):
             return jsonify(message="Unexpected or invalid controls - "
                                    "{}".format(err)), 500
 
+        if mode == 'reconfigure':
+            target_config = config.config['targets'].get(target_iqn, None)
+            if target_config is None:
+                return jsonify(message="Target: {} is not defined."
+                                       "".format(target_iqn)), 400
+
+            if client_controls and not target_config['clients']:
+                return jsonify(message="No clients found. Create clients then "
+                                       "rerun reconfigure command."), 400
+
         gateway_ip_list = []
         target = GWTarget(logger,
                           str(target_iqn),


### PR DESCRIPTION
Just 2 fixes for target/acl reconfigure handling.

1. Fix refresh after a successful reconfigure call.
2. Make sure ACL/clients are present when reconfiguring their settings, so we can make sure they are valid values.