### PR TITLE
Fix race condition after gateway creation

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -629,6 +629,8 @@ def gateway(target_iqn=None, gateway_name=None):
                                     http_method='put',
                                     api_vars=api_vars)
 
+    config.refresh()
+
     return jsonify(message="Gateway creation {}".format(resp_text)), resp_code
 
 


### PR DESCRIPTION
This was detected while using Ceph Dashboard to create an iSCSI target.

**Example:**
In this example, the Dashboard will always call the API on *node1*, to perform the following operations:

1) create target 
2) create gateway node1
3) create gateway node2
4) create gateway node3
5) disable ACL authentication

Because at step 5, node1 was not yet aware of the existance of node3 in the configuration, the `/targetauth` saved an outdated configuration that does not contain node3, so this portal was lost from the configuration (but was created in LIO).

By doing this `config.refresh` in the end of gateway creation, we guarantee that any next operation on *node1* API will use the latest config.

Signed-off-by: Ricardo Marques <rimarques@suse.com>