### PR TITLE
Fix chap config update

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -302,6 +302,8 @@ class Config(object):
                     client['auth']['mutual_password_encryption_enabled'] = \
                         (len(mpassword) > 16 and encryption_available())
                     client['auth'].pop('chap_mutual', None)
+
+                self.update_item("targets", target_iqn, target)
             self.update_item("version", None, 8)
 
         self.commit("retain")


### PR DESCRIPTION
In commit:

commit b4dd88e154c0f36f1b32a596ba539650ce173112
Author: Ricardo Marques <rimarques@suse.com>
Date:   Wed Feb 27 18:32:12 2019 +0000

    Support passwords with '/'

we just forgot to do a update_item for the target that we were updating clients for. This results in rbd-target-gw crashing with a keyvalue exception when it tries to get "username" but the old chap string is there.