### PR TITLE
regression: fix lun reconfigure failure

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -481,7 +481,7 @@ class LUN(GWObject):
         # re-add backend storage object
         so = self.lio_stg_object()
         if not so:
-            self.add_dev_to_lio(wwn)
+            so = self.add_dev_to_lio(wwn)
             if self.error:
                 raise CephiSCSIError("LUN activate failure - {}".format(self.error_msg))
 


### PR DESCRIPTION
The patch

commit 8b8f29af98cd1f59a58901ad3ff9c1573ff1a27a
Author: Mike Christie <mchristi@redhat.com>
Date:   Sat Mar 16 03:44:44 2019 -0500

    Only map the activated disk

added a regression where when doing a reconfig we can crash because the storage object is not set. This has us set the so when we have to add it ourself.