### PR TITLE
Enable/disable 'demo_mode_write_protect' when enabling/disabling ACL authentication.

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -372,6 +372,7 @@ class GWClient(GWObject):
     def _update_acl(self, target_config):
         if self.tpg.node_acls:
             self.tpg.set_attribute('generate_node_acls', 0)
+            self.tpg.set_attribute('demo_mode_write_protect', 1)
             if not target_config['acl_enabled']:
                 target_config['acl_enabled'] = True
                 self.change_count += 1

--- a/ceph_iscsi_config/target.py
+++ b/ceph_iscsi_config/target.py
@@ -234,8 +234,10 @@ class GWTarget(GWObject):
         for tpg in self.tpg_list:
             if target_config['acl_enabled']:
                 tpg.set_attribute('generate_node_acls', 0)
+                tpg.set_attribute('demo_mode_write_protect', 1)
             else:
                 tpg.set_attribute('generate_node_acls', 1)
+                tpg.set_attribute('demo_mode_write_protect', 0)
 
     def create_tpg(self, ip):
 


### PR DESCRIPTION
This is a fix for PR https://github.com/ceph/ceph-iscsi/pull/24 where we only set the `generate_node_acls` and forget to set the `demo_mode_write_protect` attribute too.


Signed-off-by: Ricardo Marques <rimarques@suse.com>