### PR TITLE
Adds `/api/targetinfo/<target_iqn>` endpoint

### DIFF
--- a/ceph_iscsi_config/target.py
+++ b/ceph_iscsi_config/target.py
@@ -685,3 +685,9 @@ class GWTarget(GWObject):
                         config.del_item('gateways', local_gw)
 
                 config.commit()
+
+    @staticmethod
+    def get_num_sessions(target_iqn):
+        with open('/sys/kernel/config/target/iscsi/{}/fabric_statistics/iscsi_instance'
+                  '/sessions'.format(target_iqn)) as sessions_file:
+            return int(sessions_file.read().rstrip('\n'))

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -1622,6 +1622,54 @@ def _targetauth(target_iqn=None):
     return jsonify(message='OK'), 200
 
 
+@app.route('/api/targetinfo/<target_iqn>', methods=['GET'])
+@requires_restricted_auth
+def targetinfo(target_iqn):
+    """
+    Returns the total number of active sessions for <target_iqn>
+    **RESTRICTED**
+    Examples:
+    curl --insecure --user admin:admin -X GET
+        http://192.168.122.69:5000/api/targetinfo/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
+    """
+    if target_iqn not in config.config['targets']:
+        return jsonify(message="Target {} does not exist".format(target_iqn)), 400
+    target_config = config.config['targets'][target_iqn]
+    gateways = target_config['portals']
+    num_sessions = 0
+    for gateway in gateways.keys():
+        resp_text, resp_code = call_api([gateway], '_targetinfo', target_iqn, http_method='get')
+        if resp_code != 200:
+            return jsonify(message="{}".format(resp_text)), resp_code
+        gateway_response = json.loads(resp_text)
+        num_sessions += gateway_response['num_sessions']
+    return jsonify({
+        "num_sessions": num_sessions
+    }), 200
+
+
+@app.route('/api/_targetinfo/<target_iqn>', methods=['GET'])
+@requires_restricted_auth
+def _targetinfo(target_iqn):
+    """
+    Returns the number of active sessions for <target_iqn> on local gateway
+    **RESTRICTED**
+    Examples:
+    curl --insecure --user admin:admin -X GET
+        http://192.168.122.69:5000/api/_targetinfo/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
+    """
+    if target_iqn not in config.config['targets']:
+        return jsonify(message="Target {} does not exist".format(target_iqn)), 400
+    target_config = config.config['targets'][target_iqn]
+    local_gw = this_host()
+    if local_gw not in target_config['portals']:
+        return jsonify(message="{} is not a portal of target {}".format(local_gw, target_iqn)), 400
+    num_sessions = GWTarget.get_num_sessions(target_iqn)
+    return jsonify({
+        "num_sessions": num_sessions
+    }), 200
+
+
 @app.route('/api/clients/<target_iqn>', methods=['GET'])
 @requires_restricted_auth
 def get_clients(target_iqn=None):

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2448,7 +2448,7 @@ def call_api(gateway_list, endpoint, element, http_method='put', api_vars=None):
 
             return fail_msg, api.response.status_code
 
-    return "successful", 200
+    return api.response.text if http_method == 'get' else 'successful', 200
 
 
 def pre_reqs_errors():


### PR DESCRIPTION
This PR adds a new endpoint that can be used to get "additional" target information (info that is not included in the config file).

For now, this endpoint is only returning the number of active sessions.

This information can be used, for instance, to be displayed in the Ceph Dashboard:

![Screenshot from 2019-03-27 21-22-44](https://user-images.githubusercontent.com/14297426/55113706-e6177b00-50d7-11e9-8bf3-24c7e3c46037.png)



