### PR TITLE
Fix deletion of gateways with multiple IPs

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -55,7 +55,7 @@ class Config(object):
                                       'mutual_username': '',
                                       'mutual_password': '',
                                       'mutual_password_encryption_enabled': False},
-                   "version": 8,
+                   "version": 9,
                    "epoch": 0,
                    "created": '',
                    "updated": ''
@@ -306,6 +306,14 @@ class Config(object):
 
                 self.update_item("targets", target_iqn, target)
             self.update_item("version", None, 8)
+
+        if self.config['version'] == 8:
+            for target_iqn, target in self.config['targets'].items():
+                for _, portal in target['portals'].items():
+                    portal['portal_ip_addresses'] = [portal['portal_ip_address']]
+                    portal.pop('portal_ip_address')
+                self.update_item("targets", target_iqn, target)
+            self.update_item("version", None, 9)
 
         self.commit("retain")
 

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -338,16 +338,18 @@ class CephiSCSIGateway(object):
         if target_config:
             local_gw = target_config['portals'].get(self.hostname)
             if local_gw:
-                local_gw_ip = local_gw['portal_ip_address']
+                local_gw_ips = local_gw['portal_ip_addresses']
 
                 target_config['portals'].pop(self.hostname)
 
                 ip_list = target_config['ip_list']
-                ip_list.remove(local_gw_ip)
+                for local_gw_ip in local_gw_ips:
+                    ip_list.remove(local_gw_ip)
 
                 for _, remote_gw_config in target_config['portals'].items():
-                    remote_gw_config["gateway_ip_list"].remove(local_gw_ip)
-                    remote_gw_config["inactive_portal_ips"].remove(local_gw_ip)
+                    for local_gw_ip in local_gw_ips:
+                        remote_gw_config["gateway_ip_list"].remove(local_gw_ip)
+                        remote_gw_config["inactive_portal_ips"].remove(local_gw_ip)
                     tpg_count = remote_gw_config["tpgs"]
                     remote_gw_config["tpgs"] = tpg_count - 1
 

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -782,7 +782,7 @@ class Gateway(UINode):
 
     display_attributes = ["name",
                           "gateway_ip_list",
-                          "portal_ip_address",
+                          "portal_ip_addresses",
                           "inactive_portal_ips",
                           "tpgs",
                           "service_state"]
@@ -864,5 +864,5 @@ class Gateway(UINode):
     def summary(self):
 
         state = self.state
-        return "{} ({})".format(self.portal_ip_address,
+        return "{} ({})".format(','.join(self.portal_ip_addresses),
                                 state), (state == "UP")

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -232,7 +232,7 @@ class ChapTest(unittest.TestCase):
                         "inactive_portal_ips": [
                             "192.168.100.202"
                         ],
-                        "portal_ip_address": "192.168.100.201",
+                        "portal_ip_addresses": ["192.168.100.201"],
                         "tpgs": 2
                     },
                     "node2": {
@@ -243,7 +243,7 @@ class ChapTest(unittest.TestCase):
                         "inactive_portal_ips": [
                             "192.168.100.201"
                         ],
-                        "portal_ip_address": "192.168.100.202",
+                        "portal_ip_addresses": ["192.168.100.202"],
                         "tpgs": 2
                     }
                 },
@@ -251,5 +251,5 @@ class ChapTest(unittest.TestCase):
             }
         },
         "updated": "2018/12/07 09:18:13",
-        "version": 8
+        "version": 9
     }


### PR DESCRIPTION
PR https://github.com/ceph/ceph-iscsi/pull/51 introduced the support for deleting a gateway but doesn't consider the case where the gateway was created with multiple IPs.

This PRs will guarantee that when deleting a gateway, all IPs of that gateway are removed.

### How to reproduce:

Create a target:
`curl --insecure --user admin:admin -X PUT https://192.168.100.201:5001/api/target/iqn.2003-01.com.redhat.iscsi-gw0`

Create one gateway with a single IP:
`curl --insecure --user admin:admin -d ip_address=192.168.100.201 -dskipchecks=true -X PUT https://192.168.100.201:5001/api/gateway/iqn.2003-01.com.redhat.iscsi-gw0/node1`

Create another gateway with **two IPs** separated by a ',':
`curl --insecure --user admin:admin -d ip_address=192.168.100.202,192.168.121.120 -dskipchecks=true -X PUT https://192.168.100.201:5001/api/gateway/iqn.2003-01.com.redhat.iscsi-gw0/node2`

Delete the second gateway:
`curl --insecure --user admin:admin -X DELETE https://192.168.100.201:5001/api/gateway/iqn.2003-01.com.redhat.iscsi-gw0/node2`

One of the IPs from the second gateway will remain in the configuration:

```
{
  "created": "2019/04/04 17:32:35",
  "discovery_auth": {
    "mutual_password": "",
    "mutual_password_encryption_enabled": false,
    "mutual_username": "",
    "password": "",
    "password_encryption_enabled": false,
    "username": ""
  },
  "disks": {},
  "epoch": 4,
  "gateways": {
    "node1": {
      "active_luns": 0,
      "created": "2019/04/04 17:34:51",
      "updated": "2019/04/04 17:34:51"
    }
  },
  "targets": {
    "iqn.2003-01.com.redhat.iscsi-gw0": {
      "acl_enabled": true,
      "clients": {},
      "controls": {},
      "created": "2019/04/04 17:34:46",
      "disks": [],
      "groups": {},
      "ip_list": [
        "192.168.100.201",
        "192.168.100.202"
      ],
      "portals": {
        "node1": {
          "gateway_ip_list": [
            "192.168.100.201",
            "192.168.100.202"
          ],
          "inactive_portal_ips": [
            "192.168.100.202"
          ],
          "portal_ip_address": "192.168.100.201",
          "tpgs": 2
        }
      },
      "updated": "2019/04/04 17:35:05"
    }
  },
  "updated": "2019/04/04 17:35:06",
  "version": 8
}
```

And if we also delete the first gateway:

`curl --insecure --user admin:admin -X DELETE https://192.168.100.201:5001/api/gateway/iqn.2003-01.com.redhat.iscsi-gw0/node1`


The "lost" IP from the second gateway still remains in the configuration:

```
{
  "created": "2019/04/04 17:32:35",
  "discovery_auth": {
    "mutual_password": "",
    "mutual_password_encryption_enabled": false,
    "mutual_username": "",
    "password": "",
    "password_encryption_enabled": false,
    "username": ""
  },
  "disks": {},
  "epoch": 5,
  "gateways": {},
  "targets": {
    "iqn.2003-01.com.redhat.iscsi-gw0": {
      "acl_enabled": true,
      "clients": {},
      "controls": {},
      "created": "2019/04/04 17:34:46",
      "disks": [],
      "groups": {},
      "ip_list": [
        "192.168.100.202"
      ],
      "portals": {},
      "updated": "2019/04/04 17:35:29"
    }
  },
  "updated": "2019/04/04 17:35:29",
  "version": 8
}
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>