### PR TITLE
Fix error when trying to get client info from `gwcli`

### DIFF
--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -1,6 +1,6 @@
 from gwcli.node import UIGroup, UINode
 
-from gwcli.utils import response_message, APIRequest, get_config
+from gwcli.utils import response_message, APIRequest, get_config, this_host
 
 from ceph_iscsi_config.client import CHAP, GWClient
 import ceph_iscsi_config.settings as settings
@@ -690,10 +690,18 @@ class Client(UINode):
     @property
     def logged_in(self):
         target_iqn = self.parent.parent.name
-        client_info = GWClient.get_client_info(target_iqn, self.client_iqn)
-        self.alias = client_info['alias']
-        self.ip_address = ','.join(client_info['ip_address'])
-        return client_info['state']
+        gateways = self.parent.parent.get_child('gateways')
+        local_gw = this_host()
+        is_local_target = len([child for child in gateways.children if child.name == local_gw]) > 0
+        if is_local_target:
+            client_info = GWClient.get_client_info(target_iqn, self.client_iqn)
+            self.alias = client_info['alias']
+            self.ip_address = ','.join(client_info['ip_address'])
+            return client_info['state']
+        else:
+            self.alias = ''
+            self.ip_address = ''
+            return ''
 
 
 class MappedLun(UINode):


### PR DESCRIPTION
This PR fixes a regression introduced in PR https://github.com/ceph/ceph-iscsi/pull/57.

How to reproduce using a "3 nodes" environment:

1) create target **"A"** with 2 portals: **"node2"** and **"node3"**
2) in **"node1"** execute `gwcli ls`
3) you will see the following error
`No such Target in configfs: /sys/kernel/config/target/iscsi/iqn.2019-02.ch.migroszh:vmware-p-hdd-data`

The full traceback is:

```
Traceback (most recent call last):
  File "/usr/bin/gwcli", line 194, in <module>
    main()
  File "/usr/bin/gwcli", line 125, in main
    shell.run_interactive()
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 905, in run_interactive
    self._cli_loop()
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 734, in _cli_loop
    self.run_cmdline(cmdline)
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 848, in run_cmdline
    self._execute_command(path, command, pparams, kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 823, in _execute_command
    result = target.execute_command(command, pparams, kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 1406, in execute_command
    return method(*pparams, **kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 710, in ui_command_ls
    tree = self._render_tree(target, depth=depth)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 861, in _render_tree
    + self._render_tree(children[i], margin, depth)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 861, in _render_tree
    + self._render_tree(children[i], margin, depth)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 861, in _render_tree
    + self._render_tree(children[i], margin, depth)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 809, in _render_tree
    children = sorted(root.children, key=sorting_keys)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 801, in sorting_keys
    m = re.search(r'(.*?)(\d+$)', str(s))
  File "/usr/lib/python3.6/site-packages/gwcli/client.py", line 338, in __str__
    return self.get_info()
  File "/usr/lib/python3.6/site-packages/gwcli/node.py", line 82, in get_info
    attr_value = getattr(self, k)
  File "/usr/lib/python3.6/site-packages/gwcli/client.py", line 693, in logged_in
    client_info = GWClient.get_client_info(target_iqn, self.client_iqn)
  File "/usr/lib/python3.6/site-packages/ceph_iscsi_config/client.py", line 245, in get_client_info
    target = Target(iscsi_fabric, target_iqn, 'lookup')
  File "/usr/lib/python3.6/site-packages/rtslib_fb/target.py", line 85, in __init__
    self._create_in_cfs_ine(mode)
  File "/usr/lib/python3.6/site-packages/rtslib_fb/node.py", line 67, in _create_in_cfs_ine
    % (self.__class__.__name__, self.path))
rtslib_fb.utils.RTSLibNotInCFS: No such Target in configfs: /sys/kernel/config/target/iscsi/iqn.2019-02.ch.migroszh:vmware-p-hdd-data
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>