### PR TITLE
Fix config update in '_targetauth' endpoint

### DIFF
--- a/ceph_iscsi_config/target.py
+++ b/ceph_iscsi_config/target.py
@@ -229,10 +229,9 @@ class GWTarget(GWObject):
             self.error = True
             self.error_msg = "Unable to delete target - {}".format(err)
 
-    def update_acl(self, config):
-        target_config = config.config["targets"][self.iqn]
+    def update_acl(self, acl_enabled):
         for tpg in self.tpg_list:
-            if target_config['acl_enabled']:
+            if acl_enabled:
                 tpg.set_attribute('generate_node_acls', 0)
                 tpg.set_attribute('demo_mode_write_protect', 1)
             else:
@@ -539,7 +538,8 @@ class GWTarget(GWObject):
                 # return to caller, with error state set
                 return
 
-            self.update_acl(config)
+            target_config = config.config["targets"][self.iqn]
+            self.update_acl(target_config['acl_enabled'])
 
             discovery_auth_config = config.config['discovery_auth']
             Discovery.set_discovery_auth_lio(discovery_auth_config['username'],
@@ -550,7 +550,6 @@ class GWTarget(GWObject):
                                              discovery_auth_config[
                                                  'mutual_password_encryption_enabled'])
 
-            target_config = config.config["targets"][self.iqn]
             gateway_group = config.config["gateways"].keys()
             if "ip_list" not in target_config:
                 target_config['ip_list'] = self.gateway_ip_list
@@ -606,7 +605,8 @@ class GWTarget(GWObject):
 
                 self.map_luns(config)
 
-                self.update_acl(config)
+                target_config = config.config["targets"][self.iqn]
+                self.update_acl(target_config['acl_enabled'])
 
             else:
                 self.error = True

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -1601,22 +1601,24 @@ def _targetauth(target_iqn=None):
     **RESTRICTED**
     """
 
+    config.refresh()
+
     local_gw = this_host()
     committing_host = request.form['committing_host']
     action = request.form['action']
 
     target = GWTarget(logger, target_iqn, [])
 
-    target_config = config.config['targets'][target_iqn]
-    if action in ['disable_acl', 'enable_acl']:
-        target_config['acl_enabled'] = (action == 'enable_acl')
-    config.update_item('targets', target_iqn, target_config)
+    acl_enabled = (action == 'enable_acl')
 
     if target.exists():
         target.load_config()
-        target.update_acl(config)
+        target.update_acl(acl_enabled)
 
     if committing_host == local_gw:
+        target_config = config.config['targets'][target_iqn]
+        target_config['acl_enabled'] = acl_enabled
+        config.update_item('targets', target_iqn, target_config)
         config.commit("retain")
 
     return jsonify(message='OK'), 200


### PR DESCRIPTION
Target configuration can only be updated by the same gateway that performs the config "commit", otherwise, we will end up with pending transactions that will silently be committed in future requests.

It may happen that these pending transactions will remove items from the target config that were added in the meanwhile (e.g. disks).

Signed-off-by: Ricardo Marques <rimarques@suse.com>