### PR TITLE
Should be possible to export config without targets

### DIFF
--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -128,9 +128,6 @@ class ISCSIRoot(UIRoot):
             return
 
         current_config = self._get_config()
-        if not current_config.get('targets'):
-            self.logger.error("Export requested, but the config is empty")
-            return
 
         if mode == 'copy':
             self.export_copy(current_config)


### PR DESCRIPTION
Even if we don't have any iSCSI target in the configuration, it should be possible to export the config because it contains other useful information like the `version`, `discovery_auth`, etc..:

```
node1:~ # gwcli export 
{
    "created": "2019/04/24 08:52:19",
    "discovery_auth": {
        "mutual_password": "wJve8EKy4qY4begYYbLf3FXoSy6+eSKqVhlYFv6nAF1N0YTjqZYuXcONgzp53T4fNnBH9H8XuFwUadleUcn+Jtx4c/wfFfnWx+wcbSNWIHOscChFY2X1jM9Kh4z3Mgo4ovWw3ogo/i5AjOD45+UBa18BlyQtS5aH/foIkS/FvKwRKrI7El/ffi+F8V9Vn0Gv7zNccLzBMDwIn3pvUBpF8N6LwmgWmUPN7ftibKQ/j3xqcylIiHyt6pnzcQKoD7CHSma/ZnMpyB2v9bn1Q+ttXDTb3bt0K5gSX6pgtSoimrTPQZ3omNesYeT9+vwWxgDjkLofE5fzGSFyJNrKo1Im9w==",
        "mutual_password_encryption_enabled": true,
        "mutual_username": "cccccccc",
        "password": "s5XdfBe2KZiLb9ztOdBLCI9AUayUpycKNLY9EplfMKN+L2BNpVWBvqOejOCFQc60NdoGq5Z2A+gdQF8nxVrp+6gVK5okU+GNqcNtdWbSGHlyXzby58bFGEUjbbkhYlLHcE0neDPjbJwmm/vk0bIs5VAwXdsVHhAcUo/wRzURLSyEuhFk5B9Iqpw1NZHC5lyT0Q3r5QgSPS8RVG/LLRD7kLzTUDbATO1QwqdgVDipak+ccHwJ311qTTAm32VuNy8iwcxf6kM1XYvDrPdtkprVCnuk2eSrDUeq49A8iyKn7vcRVKM+JgNxA1etYNvdbgpO8pRKFRtJ00QgyoEHQheVyA==",
        "password_encryption_enabled": true,
        "username": "aaaaaaaa"
    },
    "disks": {},
    "epoch": 28,
    "gateways": {},
    "targets": {},
    "updated": "2019/04/24 15:25:49",
    "version": 8
}

```

Signed-off-by: Ricardo Marques <rimarques@suse.com>