### PR TITLE
`_targetinfo` should not validate if `local_gw` is a portal

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -1662,10 +1662,6 @@ def _targetinfo(target_iqn):
     """
     if target_iqn not in config.config['targets']:
         return jsonify(message="Target {} does not exist".format(target_iqn)), 400
-    target_config = config.config['targets'][target_iqn]
-    local_gw = this_host()
-    if local_gw not in target_config['portals']:
-        return jsonify(message="{} is not a portal of target {}".format(local_gw, target_iqn)), 400
     num_sessions = GWTarget.get_num_sessions(target_iqn)
     return jsonify({
         "num_sessions": num_sessions


### PR DESCRIPTION
**Problem**
The problem is that the Ceph Dashboard is periodically querying `ceph-iscsi` to get the number of active sessions, and sometimes during deletion of a gateway Ceph Dashboard receives an error saying that "portal nodeX is not a portal of target Y".

This happens because when we call the `targetinfo` endpoint the `portal nodeX` exists but was removed before the call to `_targetinfo` on nodeX.

**Proposed solution**
I think that the simplest solution for this problem is to simply remove this validation and assume that if `_targetinfo` is called in a node that is not a portal of that target, the number of sessions on that node is zero.

Signed-off-by: Ricardo Marques <rimarques@suse.com>