### PR TITLE
`_clientinfo` should not validate if `local_gw` is a portal

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -9,7 +9,7 @@ import rtslib_fb.root as lio_root
 from socket import gethostname
 from rtslib_fb.target import NodeACL, Target, TPG
 from rtslib_fb.fabric import ISCSIFabricModule
-from rtslib_fb.utils import RTSLibError, normalize_wwn
+from rtslib_fb.utils import RTSLibError, RTSLibNotInCFS, normalize_wwn
 
 import ceph_iscsi_config.settings as settings
 
@@ -242,7 +242,10 @@ class GWClient(GWObject):
             "ip_address": []
         }
         iscsi_fabric = ISCSIFabricModule()
-        target = Target(iscsi_fabric, target_iqn, 'lookup')
+        try:
+            target = Target(iscsi_fabric, target_iqn, 'lookup')
+        except RTSLibNotInCFS:
+            return result
         for tpg in target.tpgs:
             if tpg.enable:
                 for client in tpg.node_acls:

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2194,9 +2194,6 @@ def _clientinfo(target_iqn, client_iqn):
     target_config = config.config['targets'][target_iqn]
     if client_iqn not in target_config['clients']:
         return jsonify(message="Client {} does not exist".format(client_iqn)), 400
-    local_gw = this_host()
-    if local_gw not in target_config['portals']:
-        return jsonify(message="{} is not a portal of target {}".format(local_gw, target_iqn)), 400
 
     logged_in = GWClient.get_client_info(target_iqn, client_iqn)
     return jsonify(logged_in), 200


### PR DESCRIPTION
At the moment, Ceph Dashboard is not displaying the "logged-in" information for each client but I anticipate that the same problem described in https://github.com/ceph/ceph-iscsi/pull/74 will start happening when we start displaying that information, so I'm proposing to remove the "portal" validation from `_clientinfo` too.

Signed-off-by: Ricardo Marques <rimarques@suse.com>