### PR TITLE
rbd-target-api/gw: Fix systemd deps

### DIFF
--- a/usr/lib/systemd/system/rbd-target-api.service
+++ b/usr/lib/systemd/system/rbd-target-api.service
@@ -2,9 +2,8 @@
 Description=Ceph iscsi target configuration API
 
 Requires=sys-kernel-config.mount
-After=sys-kernel-config.mount network-online.target rbd-target-gw.service
-BindsTo=rbd-target-gw.service
-Wants=network-online.target
+After=sys-kernel-config.mount network-online.target tcmu-runner.service
+Wants=network-online.target rbd-target-gw.service tcmu-runner.service
 
 [Service]
 LimitNOFILE=1048576
@@ -22,6 +21,7 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+TimeoutStopSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/system/rbd-target-gw.service
+++ b/usr/lib/systemd/system/rbd-target-gw.service
@@ -2,8 +2,9 @@
 Description=Setup system to export rbd images through LIO
 
 Requires=sys-kernel-config.mount
-After=sys-kernel-config.mount network-online.target tcmu-runner.service
-Wants=network-online.target tcmu-runner.service
+After=sys-kernel-config.mount network-online.target rbd-target-api.service
+Wants=network-online.target
+BindsTo=rbd-target-api.service
 
 [Service]
 LimitNOFILE=1048576
@@ -22,7 +23,6 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
-TimeoutStopSec=600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
rbd-target-api and rbd-target-gw used to both be able to modify the
system, so we bound api to gw so if gw went down api would be stopped
too. This prevented races where if gw started back up api could also be
modifying the system at the same time.

When we moved the target start up code to api, we no longer had this
issue, but I forgot to update the systemd deps. This patch modifies them
so:

1. gw is bound to api. This is not required to prevent modification
races like before, but if api is stopped then the system will not have
any running target so I do not think there is no point in having gw up.

2. gw is now sarted after api. We used to need the reverse because gw
did the initial setup. Now gw needs the system setup to handle statistic
calls.

Signed-off-by: Mike Christie <mchristi@redhat.com>