### PR TITLE
Logger level should be configurable

### DIFF
--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -7,6 +7,7 @@ except ImportError:
     from configparser import ConfigParser
 from distutils.util import strtobool
 
+import logging
 import re
 
 
@@ -113,7 +114,8 @@ class Settings(object):
                 "pub_key": 'iscsi-gateway-pub.key',
                 "prometheus_exporter": "true",
                 "prometheus_port": 9287,
-                "prometheus_host": "::"
+                "prometheus_host": "::",
+                "logger_level": logging.DEBUG
                 }
 
     target_defaults = {"osd_op_timeout": 30,

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2807,6 +2807,9 @@ def signal_reload(*args):
 
 if __name__ == '__main__':
 
+    settings.init()
+    logger_level = logging.getLevelName(settings.config.logger_level)
+
     # Setup signal handlers for interaction with systemd
     signal.signal(signal.SIGTERM, signal_stop)
     signal.signal(signal.SIGHUP, signal_reload)
@@ -2825,7 +2828,7 @@ if __name__ == '__main__':
     file_handler = RotatingFileHandler('/var/log/rbd-target-api/rbd-target-api.log',
                                        maxBytes=5242880,
                                        backupCount=7)
-    file_handler.setLevel(logging.DEBUG)
+    file_handler.setLevel(logger_level)
     file_format = logging.Formatter(
         "%(asctime)s %(levelname)8s [%(filename)s:%(lineno)s:%(funcName)s()] "
         "- %(message)s")
@@ -2833,8 +2836,6 @@ if __name__ == '__main__':
 
     logger.addHandler(syslog_handler)
     logger.addHandler(file_handler)
-
-    settings.init()
 
     # config is set in the outer scope, so it's easily accessible to all
     # api functions

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -62,6 +62,9 @@ def main():
 
 if __name__ == '__main__':
 
+    settings.init()
+    logger_level = logging.getLevelName(settings.config.logger_level)
+
     # setup syslog handler to help diagnostics
     logger = logging.getLogger('rbd-target-gw')
     logger.setLevel(logging.DEBUG)
@@ -76,12 +79,11 @@ if __name__ == '__main__':
     file_handler = RotatingFileHandler('/var/log/rbd-target-gw/rbd-target-gw.log',
                                        maxBytes=5242880,
                                        backupCount=7)
-    file_handler.setLevel(logging.DEBUG)
+    file_handler.setLevel(logger_level)
     file_format = logging.Formatter("%(asctime)s [%(levelname)8s] - %(message)s")
     file_handler.setFormatter(file_format)
 
     logger.addHandler(syslog_handler)
     logger.addHandler(file_handler)
 
-    settings.init()
     main()


### PR DESCRIPTION
With this PR, `rbd-target-api` / `rbd-target-gw` logger level will be configurable (defaults to 'DEBUG').

Signed-off-by: Ricardo Marques <rimarques@suse.com>