### PR TITLE
Fix race condition on target disk add

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -834,6 +834,8 @@ def _target_disk(target_iqn=None):
     **RESTRICTED**
     """
 
+    config.refresh()
+
     disk = request.form.get('disk')
     pool, image = disk.split('/', 1)
     disk_config = config.config['disks'][disk]


### PR DESCRIPTION
Due to the fact that disk creation (`/api/_disk` endpoint) [is only executed in the local gw](https://github.com/ceph/ceph-iscsi/blob/master/rbd-target-api.py#L987), we have to force a config refresh when adding a disk to a target, otherwise, we may face the following error on other gateways:

```
File "/usr/bin/rbd-target-api", line 839, in _target_disk
    disk_config = config.config['disks'][disk]
KeyError: 'rbd/lun1'
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>