### PR TITLE
rbd-target-gw/api systemd dep fix

### DIFF
--- a/usr/lib/systemd/system/rbd-target-api.service
+++ b/usr/lib/systemd/system/rbd-target-api.service
@@ -3,7 +3,7 @@ Description=Ceph iscsi target configuration API
 
 Requires=sys-kernel-config.mount
 After=sys-kernel-config.mount network-online.target tcmu-runner.service
-Wants=network-online.target rbd-target-gw.service tcmu-runner.service
+Wants=network-online.target tcmu-runner.service
 
 [Service]
 LimitNOFILE=1048576

--- a/usr/lib/systemd/system/rbd-target-gw.service
+++ b/usr/lib/systemd/system/rbd-target-gw.service
@@ -4,7 +4,6 @@ Description=Setup system to export rbd images through LIO
 Requires=sys-kernel-config.mount
 After=sys-kernel-config.mount network-online.target rbd-target-api.service
 Wants=network-online.target
-BindsTo=rbd-target-api.service
 
 [Service]
 LimitNOFILE=1048576


### PR DESCRIPTION
Newer versions of systemd will return error when trying to start
rbd-target-gw, because it detects ordering and dependency issue
with rbd-target-api.

This removes the bind/wants between the 2 services. The bind/wants was
not required and was added to make it more convenient for users so that
the services stopped and restarted together. I can just doc this instead.