### PR TITLE
Add support for enabling FQDN

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -6,7 +6,6 @@ import os
 
 import rtslib_fb.root as lio_root
 
-from socket import gethostname
 from rtslib_fb.target import NodeACL, Target, TPG
 from rtslib_fb.fabric import ISCSIFabricModule
 from rtslib_fb.utils import RTSLibError, RTSLibNotInCFS, normalize_wwn
@@ -14,7 +13,7 @@ from rtslib_fb.utils import RTSLibError, RTSLibNotInCFS, normalize_wwn
 import ceph_iscsi_config.settings as settings
 
 from ceph_iscsi_config.common import Config
-from ceph_iscsi_config.utils import encryption_available, CephiSCSIError
+from ceph_iscsi_config.utils import encryption_available, CephiSCSIError, this_host
 from ceph_iscsi_config.gateway_object import GWObject
 
 
@@ -639,7 +638,7 @@ class GWClient(GWObject):
 
                 if self.commit_enabled:
 
-                    if update_host == gethostname().split('.')[0]:
+                    if update_host == this_host():
                         # update the config object with this clients settings
                         self.logger.debug("Updating config object metadata "
                                           "for '{}'".format(self.iqn))
@@ -666,7 +665,7 @@ class GWClient(GWObject):
                 else:
                     # remove this client from the config
 
-                    if update_host == gethostname().split('.')[0]:
+                    if update_host == this_host():
                         self.logger.debug("Removing {} from the config "
                                           "object".format(self.iqn))
                         target_config['clients'].pop(self.iqn)

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -3,7 +3,6 @@ import rbd
 import re
 
 from time import sleep
-from socket import gethostname
 
 from rtslib_fb import UserBackedStorageObject, root
 from rtslib_fb.utils import RTSLibError
@@ -303,9 +302,9 @@ class LUN(GWObject):
         self.size_bytes = convert_2_bytes(size)
         self.config_key = '{}/{}'.format(self.pool, self.image)
 
-        # the allocating host could be fqdn or shortname - but the config
-        # only uses shortname so it needs to be converted to shortname format
-        self.allocating_host = allocating_host.split('.')[0]
+        # the allocating host could be fqdn or shortname
+        fqdn_enabled = settings.config.fqdn_enabled
+        self.allocating_host = allocating_host if fqdn_enabled else allocating_host.split('.')[0]
         self.backstore = backstore
         self.backstore_object_name = backstore_object_name
 
@@ -333,7 +332,7 @@ class LUN(GWObject):
                               "continue".format(self.pool))
 
     def remove_lun(self, preserve_image):
-        this_host = gethostname().split('.')[0]
+        local_gw = this_host()
         self.logger.info("LUN deletion request received, rbd removal to be "
                          "performed by {}".format(self.allocating_host))
 
@@ -360,7 +359,7 @@ class LUN(GWObject):
 
         rbd_image = RBDDev(self.image, '0G', self.backstore, self.pool)
 
-        if this_host == self.allocating_host:
+        if local_gw == self.allocating_host:
             # by using the allocating host we ensure the delete is not
             # issue by several hosts when initiated through ansible
             if not preserve_image:
@@ -376,7 +375,7 @@ class LUN(GWObject):
             self.config.commit()
 
     def unmap_lun(self, target_iqn):
-        this_host = gethostname().split('.')[0]
+        local_gw = this_host()
         self.logger.info("LUN unmap request received, config commit to be "
                          "performed by {}".format(self.allocating_host))
 
@@ -405,7 +404,7 @@ class LUN(GWObject):
         if self.error:
             return
 
-        if this_host == self.allocating_host:
+        if local_gw == self.allocating_host:
             # by using the allocating host we ensure the delete is not
             # issue by several hosts when initiated through ansible
 
@@ -582,9 +581,9 @@ class LUN(GWObject):
         self.logger.debug("rados pool '{}' contains the following - "
                           "{}".format(self.pool, disk_list))
 
-        this_host = gethostname().split('.')[0]
+        local_gw = this_host()
         self.logger.debug("Hostname Check - this host is {}, target host for "
-                          "allocations is {}".format(this_host,
+                          "allocations is {}".format(local_gw,
                                                      self.allocating_host))
 
         rbd_image = RBDDev(self.image, self.size_bytes, self.backstore, self.pool)
@@ -593,7 +592,7 @@ class LUN(GWObject):
         # if the image required isn't defined, create it!
         if self.image not in disk_list:
             # create the requested disk if this is the 'owning' host
-            if this_host == self.allocating_host:
+            if local_gw == self.allocating_host:
 
                 rbd_image.create()
 
@@ -644,7 +643,7 @@ class LUN(GWObject):
 
         # if updates_made is not set, the disk pre-exists so on the owning
         # host see if it needs to be resized
-        if self.num_changes == 0 and this_host == self.allocating_host:
+        if self.num_changes == 0 and local_gw == self.allocating_host:
 
             # check the size, and update if needed
             rbd_image.rbd_size()
@@ -672,7 +671,7 @@ class LUN(GWObject):
             # this image has not been defined to this hosts LIO, so check the
             # config for the details and if it's  missing define the
             # wwn/alua_state and update the config
-            if this_host == self.allocating_host:
+            if local_gw == self.allocating_host:
                 # first check to see if the device needs adding
                 try:
                     wwn = self.config.config['disks'][self.config_key]['wwn']
@@ -779,7 +778,7 @@ class LUN(GWObject):
 
         # the owning host for an image is the only host that commits to the
         # config
-        if this_host == self.allocating_host and self.config.changed:
+        if local_gw == self.allocating_host and self.config.changed:
 
             self.logger.debug("(LUN.allocate) Committing change(s) to the "
                               "config object in pool {}".format(self.pool))

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -302,9 +302,7 @@ class LUN(GWObject):
         self.size_bytes = convert_2_bytes(size)
         self.config_key = '{}/{}'.format(self.pool, self.image)
 
-        # the allocating host could be fqdn or shortname
-        fqdn_enabled = settings.config.fqdn_enabled
-        self.allocating_host = allocating_host if fqdn_enabled else allocating_host.split('.')[0]
+        self.allocating_host = allocating_host
         self.backstore = backstore
         self.backstore_object_name = backstore_object_name
 

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -117,8 +117,7 @@ class Settings(object):
                 "prometheus_exporter": "true",
                 "prometheus_port": 9287,
                 "prometheus_host": "::",
-                "logger_level": logging.DEBUG,
-                "fqdn_enabled": "false"
+                "logger_level": logging.DEBUG
                 }
 
     exclude_from_hash = ["cluster_client_name",

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -117,7 +117,8 @@ class Settings(object):
                 "prometheus_exporter": "true",
                 "prometheus_port": 9287,
                 "prometheus_host": "::",
-                "logger_level": logging.DEBUG
+                "logger_level": logging.DEBUG,
+                "fqdn_enabled": "false"
                 }
 
     exclude_from_hash = ["cluster_client_name",

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -278,10 +278,9 @@ def get_time():
 
 def this_host():
     """
-    return the local machine's fqdn or shortname
+    return the local machine's fqdn
     """
-    fqdn_enabled = settings.config.fqdn_enabled
-    return socket.getfqdn() if fqdn_enabled else socket.gethostname().split('.')[0]
+    return socket.getfqdn()
 
 
 def encryption_available():

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -281,7 +281,7 @@ def this_host():
     return the local machine's fqdn or shortname
     """
     fqdn_enabled = settings.config.fqdn_enabled
-    return socket.gethostname() if fqdn_enabled else socket.gethostname().split('.')[0]
+    return socket.getfqdn() if fqdn_enabled else socket.gethostname().split('.')[0]
 
 
 def encryption_available():

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -278,9 +278,10 @@ def get_time():
 
 def this_host():
     """
-    return the local machine's shortname
+    return the local machine's fqdn or shortname
     """
-    return socket.gethostname().split('.')[0]
+    fqdn_enabled = settings.config.fqdn_enabled
+    return socket.gethostname() if fqdn_enabled else socket.gethostname().split('.')[0]
 
 
 def encryption_available():

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -1,10 +1,10 @@
 from gwcli.node import UIGroup, UINode
 
-from gwcli.utils import response_message, APIRequest, get_config, this_host
+from gwcli.utils import response_message, APIRequest, get_config
 
 from ceph_iscsi_config.client import CHAP, GWClient
 import ceph_iscsi_config.settings as settings
-from ceph_iscsi_config.utils import human_size
+from ceph_iscsi_config.utils import human_size, this_host
 
 from rtslib_fb.utils import normalize_wwn, RTSLibError
 

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -5,11 +5,11 @@ from gwcli.node import UIGroup, UINode, UIRoot
 from gwcli.hostgroup import HostGroups
 from gwcli.storage import Disks, TargetDisks
 from gwcli.client import Clients
-from gwcli.utils import (this_host, response_message, GatewayAPIError,
+from gwcli.utils import (response_message, GatewayAPIError,
                          GatewayError, APIRequest, console_message, get_config)
 
 import ceph_iscsi_config.settings as settings
-from ceph_iscsi_config.utils import (normalize_ip_address, format_lio_yes_no)
+from ceph_iscsi_config.utils import (normalize_ip_address, format_lio_yes_no, this_host)
 from ceph_iscsi_config.target import GWTarget
 
 from gwcli.ceph import CephGroup

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -752,10 +752,13 @@ class GatewayGroup(UIGroup):
                                         gateway_name,
                                         settings.config.api_port))
 
+        api = APIRequest('{}/sysinfo/hostname'.format(new_gw_endpoint))
+        api.get()
+        gateway_hostname = api.response.json()['data']
         config = self.parent.parent.parent._get_config(endpoint=new_gw_endpoint)
         target_config = config['targets'][target_iqn]
-        portal_config = target_config['portals'][gateway_name]
-        Gateway(self, gateway_name, portal_config)
+        portal_config = target_config['portals'][gateway_hostname]
+        Gateway(self, gateway_hostname, portal_config)
 
         self.logger.info('ok')
 

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -13,9 +13,9 @@ from gwcli.node import UIGroup, UINode
 from gwcli.client import Clients
 
 from gwcli.utils import (console_message, response_message, GatewayAPIError,
-                         this_host, APIRequest, valid_snapshot_name, get_config)
+                         APIRequest, valid_snapshot_name, get_config)
 
-from ceph_iscsi_config.utils import valid_size, convert_2_bytes, human_size
+from ceph_iscsi_config.utils import valid_size, convert_2_bytes, human_size, this_host
 from ceph_iscsi_config.lun import LUN
 
 import ceph_iscsi_config.settings as settings

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -36,7 +36,7 @@ def this_host():
     return the local machine's fqdn or shortname
     """
     fqdn_enabled = settings.config.fqdn_enabled
-    return socket.gethostname() if fqdn_enabled else socket.gethostname().split('.')[0]
+    return socket.getfqdn() if fqdn_enabled else socket.gethostname().split('.')[0]
 
 
 def get_config():

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -1,4 +1,3 @@
-import socket
 import requests
 from requests import Response
 import sys
@@ -12,7 +11,7 @@ from rtslib_fb.utils import normalize_wwn, RTSLibError
 from ceph_iscsi_config.client import GWClient
 import ceph_iscsi_config.settings as settings
 from ceph_iscsi_config.utils import (resolve_ip_addresses,
-                                     CephiSCSIError)
+                                     CephiSCSIError, this_host)
 
 __author__ = 'Paul Cuzner'
 
@@ -29,14 +28,6 @@ def readcontents(filename):
     with open(filename, 'r') as input_file:
         content = input_file.read().rstrip()
     return content
-
-
-def this_host():
-    """
-    return the local machine's fqdn or shortname
-    """
-    fqdn_enabled = settings.config.fqdn_enabled
-    return socket.getfqdn() if fqdn_enabled else socket.gethostname().split('.')[0]
 
 
 def get_config():

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -33,9 +33,10 @@ def readcontents(filename):
 
 def this_host():
     """
-    return the local machine's shortname
+    return the local machine's fqdn or shortname
     """
-    return socket.gethostname().split('.')[0]
+    fqdn_enabled = settings.config.fqdn_enabled
+    return socket.gethostname() if fqdn_enabled else socket.gethostname().split('.')[0]
 
 
 def get_config():

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -34,9 +34,9 @@ from ceph_iscsi_config.client import GWClient, CHAP
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.utils import (normalize_ip_literal, resolve_ip_addresses,
                                      ip_addresses, read_os_release,
-                                     format_lio_yes_no, CephiSCSIError)
+                                     format_lio_yes_no, CephiSCSIError, this_host)
 
-from gwcli.utils import (this_host, APIRequest, valid_gateway, valid_client,
+from gwcli.utils import (APIRequest, valid_gateway, valid_client,
                          valid_credentials, get_remote_gateways, valid_snapshot_name,
                          GatewayAPIError)
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -25,11 +25,26 @@ class ChapTest(unittest.TestCase):
 
     def test_upgrade_config(self):
         gateway_conf_initial = json.dumps(self.gateway_conf_initial)
+
+        # First, the upgrade is executed on node1
         with mock.patch.object(Config, 'init_config', return_value=True), \
                 mock.patch.object(Config, '_read_config_object',
                                   return_value=gateway_conf_initial), \
-                mock.patch.object(Config, 'commit'):
+                mock.patch.object(Config, 'commit'), \
+                mock.patch("socket.gethostname", return_value='node1'), \
+                mock.patch("socket.getfqdn", return_value='node1.ceph.local'):
             config = Config(self.logger)
+
+        # And then, the upgrade is executed on node2
+        current_config = json.dumps(config.config)
+        with mock.patch.object(Config, 'init_config', return_value=True), \
+                mock.patch.object(Config, '_read_config_object',
+                                  return_value=current_config), \
+                mock.patch.object(Config, 'commit'), \
+                mock.patch("socket.gethostname", return_value='node2'),\
+                mock.patch("socket.getfqdn", return_value='node2.ceph.local'):
+            config = Config(self.logger)
+
             self.maxDiff = None
 
             iqn = 'iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw'
@@ -148,7 +163,7 @@ class ChapTest(unittest.TestCase):
                 },
                 "created": "2018/12/07 09:18:04",
                 "image": "disk_1",
-                "owner": "node1",
+                "owner": "node1.ceph.local",
                 "backstore": "user:rbd",
                 "backstore_object_name": "rbd.disk_1",
                 "pool": "rbd",
@@ -167,12 +182,12 @@ class ChapTest(unittest.TestCase):
         },
         "epoch": 19,
         "gateways": {
-            "node1": {
+            "node1.ceph.local": {
                 "active_luns": 1,
                 "created": "2018/12/07 09:18:07",
                 "updated": "2018/12/07 09:18:08"
             },
-            "node2": {
+            "node2.ceph.local": {
                 "active_luns": 0,
                 "created": "2018/12/07 09:18:09",
                 "updated": "2018/12/07 09:18:10"
@@ -224,7 +239,7 @@ class ChapTest(unittest.TestCase):
                     "192.168.100.202"
                 ],
                 "portals": {
-                    "node1": {
+                    "node1.ceph.local": {
                         "gateway_ip_list": [
                             "192.168.100.201",
                             "192.168.100.202"
@@ -235,7 +250,7 @@ class ChapTest(unittest.TestCase):
                         "portal_ip_addresses": ["192.168.100.201"],
                         "tpgs": 2
                     },
-                    "node2": {
+                    "node2.ceph.local": {
                         "gateway_ip_list": [
                             "192.168.100.201",
                             "192.168.100.202"
@@ -251,5 +266,5 @@ class ChapTest(unittest.TestCase):
             }
         },
         "updated": "2018/12/07 09:18:13",
-        "version": 9
+        "version": 10
     }


### PR DESCRIPTION
With this PR will be possible to use FQDNs instead of host shortnames.

If `fqdn_enabled` setting is `true` (defaults to `false`), then FQDN will be used, otherwise, nothing changes from the previous implementation.

Signed-off-by: Ricardo Marques <rimarques@suse.com>