### PR TITLE
Fix problem deleting target that contains clients/disks

### DIFF
--- a/ceph_iscsi_config/target.py
+++ b/ceph_iscsi_config/target.py
@@ -657,6 +657,8 @@ class GWTarget(GWObject):
             if self.exists():
                 self.load_config()
                 self.clear_config(config)
+                if self.error:
+                    return
             target_config = config.config["targets"][self.iqn]
             if len(target_config['portals']) == 0:
                 config.del_item('targets', self.iqn)


### PR DESCRIPTION
Deleting a target that has clients/disks results in a portal being removed from `gateway.conf` but not from the `LIO`.

How to reproduce

1) Create a target with disks/clients

2) Confirm that you have >= 2 portals on `gateway.conf` by running `gwcli / export`

3) Try to delete that target, you will see an expected error: 

```
/iscsi-targets> delete iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
CMD: /iscsi delete iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
Failed - failed on node1. Clients(1) and disks(1) must be removed before the gateways
```

4) Verify that one portal was **incorrectly** removed from the `gateway.conf` by running `gwcli / export` again

Signed-off-by: Ricardo Marques <rimarques@suse.com>