### PR TITLE
Fix python3 issue when running target reconfigure

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -397,7 +397,7 @@ def local_target_reconfigure(target_iqn, tpg_controls, client_controls):
     target_config = config.config['targets'][target_iqn]
     for client_iqn in target_config['clients']:
         client_metadata = target_config['clients'][client_iqn]
-        image_list = client_metadata['luns'].keys()
+        image_list = list(client_metadata['luns'].keys())
         client_auth_config = client_metadata['auth']
         client_chap = CHAP(client_auth_config['username'],
                            client_auth_config['password'],


### PR DESCRIPTION
This PR fixes the following error when trying to execute `/iscsi-target...-gw:iscsi-igw> reconfigure cmdsn_depth 512` on a python3 environment:

```
2019-05-24 09:50:21,629    ERROR [rbd-target-api:114:unhandled_exception()] - Unhandled Exception
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/python3.6/site-packages/ceph_iscsi-3.0-py3.6.egg/EGG-INFO/scripts/rbd-target-api", line 107, in decorated
  File "/usr/lib/python3.6/site-packages/ceph_iscsi-3.0-py3.6.egg/EGG-INFO/scripts/rbd-target-api", line 331, in target
  File "/usr/lib/python3.6/site-packages/ceph_iscsi-3.0-py3.6.egg/EGG-INFO/scripts/rbd-target-api", line 419, in local_target_reconfigure
  File "/usr/lib/python3.6/site-packages/ceph_iscsi-3.0-py3.6.egg/ceph_iscsi_config/client.py", line 64, in __init__
    if isinstance(image_list[0], tuple):
TypeError: 'dict_keys' object does not support indexing
```

Fixes: https://github.com/ceph/ceph-iscsi/issues/88

Signed-off-by: Ricardo Marques <rimarques@suse.com>