### PR TITLE
Adds support for multiple IPs per gateway on gwcli

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -48,7 +48,7 @@ Requires:       python-rtslib >= 2.1.fb68
 Requires:       rpm-python >= 4.11
 Requires:       python-cryptography
 Requires:       python-flask >= 0.10.1
-Requires:       python-configshell
+Requires:       python-configshell >= 1.1.fb25
 %if 0%{?rhel} == 7
 Requires:       pyOpenSSL
 %else
@@ -68,10 +68,10 @@ Requires:       python3-rpm >= 4.11
 BuildRequires:  python-rpm-macros
 BuildRequires:  fdupes
 Requires:       python3-Flask >= 0.10.1
-Requires:       python3-configshell-fb
+Requires:       python3-configshell-fb >= 1.1.25
 %else
 Requires:       python3-flask >= 0.10.1
-Requires:       python3-configshell
+Requires:       python3-configshell >= 1.1.fb25
 %endif
 %endif
 

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -657,15 +657,15 @@ class GatewayGroup(UIGroup):
             hosts_object = self.parent.get_child("hosts")
             hosts_object.reset()
 
-    def ui_command_create(self, gateway_name, ip_address, nosync=False,
+    def ui_command_create(self, gateway_name, ip_addresses, nosync=False,
                           skipchecks='false'):
         """
         Define a gateway to the gateway group for this iscsi target. The
         first host added should be the gateway running the command
 
         gateway_name ... should resolve to the hostname of the gateway
-        ip_address ..... is the IPv4/IPv6 address of the interface the iscsi
-                         portal should use
+        ip_addresses ... are the IPv4/IPv6 addresses of the interfaces the
+                         iSCSI portals should use
         nosync ......... by default new gateways are sync'd with the
                          existing configuration by cli. By specifying nosync
                          the sync step is bypassed - so the new gateway
@@ -678,10 +678,10 @@ class GatewayGroup(UIGroup):
                          to result in an unstable configuration.
         """
 
-        ip_address = normalize_ip_address(ip_address)
+        ip_addresses = [normalize_ip_address(ip_address) for ip_address in ip_addresses.split(',')]
         self.logger.debug("CMD: ../gateways/ create {} {} "
                           "nosync={} skipchecks={}".format(gateway_name,
-                                                           ip_address,
+                                                           ip_addresses,
                                                            nosync,
                                                            skipchecks))
 
@@ -730,7 +730,7 @@ class GatewayGroup(UIGroup):
         gw_rqst = gw_api + '/gateway/{}/{}'.format(target_iqn, gateway_name)
         gw_vars = {"nosync": nosync,
                    "skipchecks": skipchecks,
-                   "ip_address": ip_address}
+                   "ip_address": ','.join(ip_addresses)}
 
         api = APIRequest(gw_rqst, data=gw_vars)
         api.put()

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -566,7 +566,7 @@ def gateway(target_iqn=None, gateway_name=None):
     required for PUT only.
     :param target_iqn: (str) target iqn
     :param gateway_name: (str) gateway name
-    :param ip_address: (str) IPv4/IPv6 address iSCSI should use
+    :param ip_address: (str) IPv4/IPv6 addresses iSCSI should use
     :param nosync: (bool) whether to sync the LIO objects to the new gateway
            default: FALSE
     :param skipchecks: (bool) whether to skip OS/software versions checks
@@ -595,7 +595,11 @@ def gateway(target_iqn=None, gateway_name=None):
     target_config = config.config['targets'][target_iqn]
 
     if request.method == 'PUT':
-        ip_address = request.form.get('ip_address')
+        if gateway_name in target_config['portals']:
+            err_str = "Gateway already exists in configuration"
+            logger.error(err_str)
+            return jsonify(message=err_str), 400
+        ip_address = request.form.get('ip_address').split(',')
         nosync = request.form.get('nosync', 'false')
         skipchecks = request.form.get('skipchecks', 'false')
 
@@ -623,7 +627,7 @@ def gateway(target_iqn=None, gateway_name=None):
             nosync = 'true'
 
         gateway_ip_list = target_config.get('ip_list', [])
-        gateway_ip_list.append(ip_address)
+        gateway_ip_list += ip_address
 
         op = 'creation'
         api_vars = {"gateway_ip_list": ",".join(gateway_ip_list),


### PR DESCRIPTION
When using `ceph-iscsi` REST API directly (e.g. from Ceph Dashboard) multiple IPs for a single gateway is already supported (if `skipchecks` is set to `true`), but `gwcli` only accepts one IP.

This PR changes the `gwcli` to also accept multiple comma separated IPs (without the need to set `skipchecks=true`).

E.g.:
```
/iscsi-target...0343/gateways> create node1 192.168.100.201,192.168.121.236 
```

Note that `configshell-fb` only supports `,` since https://github.com/open-iscsi/configshell-fb/commit/341018797fcb47bdeda1a5c87266d4b14f51c945 which means that multiple IPs on `gwcli` requires `configshell-fb` >= `v1.1.fb25` (single IP gateways will still work when using older versions of `configshell-fb`)

Signed-off-by: Ricardo Marques <rimarques@suse.com>