### PR TITLE
Fix openssl rpm dep

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -48,6 +48,11 @@ Requires:       rpm-python >= 4.11
 Requires:       python-cryptography
 Requires:       python-flask >= 0.10.1
 Requires:       python-configshell
+%if 0%{?rhel} == 7
+Requires:       pyOpenSSL
+%else
+Requires:       python-pyOpenSSL
+%endif
 %else
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -56,6 +61,7 @@ Requires:       python3-rbd >= 10.2.2
 Requires:       python3-netifaces >= 0.10.4
 Requires:       python3-rtslib >= 2.1.fb67
 Requires:       python3-cryptography
+Requires:       python3-pyOpenSSL
 Requires:       python3-rpm >= 4.11
 %if 0%{?suse_version}
 BuildRequires:  python-rpm-macros


### PR DESCRIPTION
rbd-target-api requires ssl, so add it to the spec file.

There is some weirdness here in that in RHEL 7 the package is named
pyOpenSSL, but in suse and RHEL8 and modern Fedora versions the package
was renamed to python-pyOpenSSL/python2-pyOpenSSL for the python2 based
package. In python3 it is always name python3-pyOpenSSL for all distros.