### PR TITLE
Remove config hash check validation

### DIFF
--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -5,7 +5,6 @@ import rados
 import rbd
 import re
 import datetime
-import hashlib
 import os
 import rpm
 
@@ -283,30 +282,6 @@ def this_host():
     return the local machine's shortname
     """
     return socket.gethostname().split('.')[0]
-
-
-def gen_file_hash(filename, hash_type='sha256'):
-    """
-    generate a hash(default sha256) of a file and return the result
-    :param filename: filename to generate the checksum for
-    :param hash_type: type of checksum to generate
-    :return: checkum (str)
-    """
-
-    if (hash_type not in ['sha1', 'sha256', 'sha512', 'md5'] or not
-            os.path.exists(filename)):
-        return ''
-
-    hash_function = getattr(hashlib, hash_type)
-    h = hash_function()
-
-    with open(filename, 'rb') as file_in:
-        chunk = 0
-        while chunk != b'':
-            chunk = file_in.read(1024)
-            h.update(chunk)
-
-    return h.hexdigest()
 
 
 def valid_rpm(in_rpm):

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -11,7 +11,7 @@ from rtslib_fb.utils import normalize_wwn, RTSLibError
 
 from ceph_iscsi_config.client import GWClient
 import ceph_iscsi_config.settings as settings
-from ceph_iscsi_config.utils import (resolve_ip_addresses, gen_file_hash,
+from ceph_iscsi_config.utils import (resolve_ip_addresses,
                                      CephiSCSIError)
 
 __author__ = 'Paul Cuzner'
@@ -112,26 +112,6 @@ def valid_gateway(target_iqn, gw_name, gw_ip, config):
                 "IPs are :{}".format(gw_ip,
                                      gw_name,
                                      ','.join(target_ips)))
-
-    # check that config file on the new gateway matches the local machine
-    api = APIRequest(gw_api + '/sysinfo/checkconf')
-    api.get()
-    if api.response.status_code != 200:
-        return ("checkconf API call to {} failed with "
-                "code".format(gw_name,
-                              api.response.status_code))
-
-    # compare the hash of the new gateways conf file with the local one
-    local_hash = gen_file_hash('/etc/ceph/iscsi-gateway.cfg')
-    try:
-        remote_hash = str(api.response.json()['data'])
-    except Exception:
-        remote_hash = None
-
-    if local_hash != remote_hash:
-        return ("/etc/ceph/iscsi-gateway.cfg on {} does "
-                "not match the local version. Correct and "
-                "retry request".format(gw_name))
 
     # Check for package version dependencies
     api = APIRequest(gw_api + '/sysinfo/checkversions')

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -34,7 +34,7 @@ from ceph_iscsi_config.lun import RBDDev, LUN
 from ceph_iscsi_config.client import GWClient, CHAP
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.utils import (normalize_ip_literal, resolve_ip_addresses,
-                                     ip_addresses, gen_file_hash, valid_rpm,
+                                     ip_addresses, valid_rpm,
                                      format_lio_yes_no, CephiSCSIError)
 
 from gwcli.utils import (this_host, APIRequest, valid_gateway, valid_client,
@@ -166,7 +166,7 @@ def get_api_info():
 def get_sys_info(query_type=None):
     """
     Provide system information based on the query_type
-    Valid query types are: ip_addresses, checkconf and checkversions
+    Valid query types are: ip_addresses and checkversions
     **RESTRICTED**
     Examples:
     curl --insecure --user admin:admin -X GET http://192.168.122.69:5000/api/sysinfo/ip_addresses
@@ -179,11 +179,6 @@ def get_sys_info(query_type=None):
     if query_type == 'hostname':
 
         return jsonify(data=this_host()), 200
-
-    elif query_type == 'checkconf':
-
-        local_hash = gen_file_hash('/etc/ceph/iscsi-gateway.cfg')
-        return jsonify(data=local_hash), 200
 
     elif query_type == 'checkversions':
 


### PR DESCRIPTION
While trying to use different `cluster_client_name` for each gateway I've noticed that, when adding a new gateway, `ceph-iscsi` is forcing the new gateway to have the same `/etc/ceph/iscsi-gateway.cfg` file hash (same "comments", same `cluster_client_name`, same `logger_level`, etc.).

I don't understand why we have this restriction, so this PR is removing this validation.

If we really need this check, maybe we should find a different way to implement it in order to allow some settings to be different across gateways. Thoughts?

Signed-off-by: Ricardo Marques <rimarques@suse.com>