### PR TITLE
spec: fix rhel conditional blocks

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -68,7 +68,7 @@ Requires:       python3-configshell
 %endif
 %endif
 
-%if 0%{?rhel} < 8
+%if 0%{?rhel} == 7
 BuildRequires: systemd
 %else
 BuildRequires: systemd-rpm-macros
@@ -136,7 +136,7 @@ ln -s service %{buildroot}%{_sbindir}/rcrbd-target-api
 %endif
 
 %post
-%if 0%{?rhel} < 8
+%if 0%{?rhel} == 7
 /bin/systemctl --system daemon-reload &> /dev/null || :
 /bin/systemctl --system enable rbd-target-gw &> /dev/null || :
 /bin/systemctl --system enable rbd-target-api &> /dev/null || :
@@ -159,7 +159,7 @@ ln -s service %{buildroot}%{_sbindir}/rcrbd-target-api
 %endif
 
 %postun
-%if 0%{?rhel} < 8
+%if 0%{?rhel} == 7
 /bin/systemctl --system daemon-reload &> /dev/null || :
 %endif
 %if 0%{?fedora} || 0%{?rhel} >= 8


### PR DESCRIPTION
35f0532990356e00e79656a8cdae379885be8725 introduced the following conditional:

```    
%if 0%{?rhel} < 8
...
%endif
```

This is problematic because the conditional will evaluate to true if the macro
`%rhel` is undefined, which is the case on openSUSE for example.