### PR TITLE
SUSE is now supported

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -37,6 +37,7 @@ BuildArch:      noarch
 Obsoletes:      ceph-iscsi-config
 Obsoletes:      ceph-iscsi-cli
 
+Requires:       tcmu-runner >= 1.3.0
 %if 0%{?with_python2}
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools

--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -37,7 +37,7 @@ BuildArch:      noarch
 Obsoletes:      ceph-iscsi-config
 Obsoletes:      ceph-iscsi-cli
 
-Requires:       tcmu-runner >= 1.3.0
+Requires:       tcmu-runner >= 1.4.0
 %if 0%{?with_python2}
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools


### PR DESCRIPTION
This PR adds SUSE to the list of supported OS.

By default, we are now relying on `/etc/os-release` to get the release version, but for 'redhat', we are still using `platform.linux_distribution` because it has more precision (it also returns the release minor version), but note that `platform` is deprecated so this should be adapted in the future. 

Additionally, the `rpm` version checks on the REST API were moved to the `spec` file only.

Signed-off-by: Ricardo Marques <rimarques@suse.com>