### PR TITLE
spec: actually requires rtslib >= v2.1.fb68

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -43,7 +43,7 @@ BuildRequires:  python2-setuptools
 Requires:       python-rados >= 10.2.2
 Requires:       python-rbd >= 10.2.2
 Requires:       python-netifaces >= 0.10.4
-Requires:       python-rtslib >= 2.1.fb67
+Requires:       python-rtslib >= 2.1.fb68
 Requires:       rpm-python >= 4.11
 Requires:       python-cryptography
 Requires:       python-flask >= 0.10.1
@@ -59,7 +59,7 @@ BuildRequires:  python3-setuptools
 Requires:       python3-rados >= 10.2.2
 Requires:       python3-rbd >= 10.2.2
 Requires:       python3-netifaces >= 0.10.4
-Requires:       python3-rtslib >= 2.1.fb67
+Requires:       python3-rtslib >= 2.1.fb68
 Requires:       python3-cryptography
 Requires:       python3-pyOpenSSL
 Requires:       python3-rpm >= 4.11


### PR DESCRIPTION
The changes introduced in commit 9637223b9d8cee3abc527f58fc9e14a1bcbe4b29
are first available in that release.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>