### PR TITLE
Fix config hash check validation 

### DIFF
--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -120,13 +120,9 @@ class Settings(object):
                 "logger_level": logging.DEBUG
                 }
 
-    sync_required = ["cluster_name",
-                     "pool",
-                     "api_port",
-                     "api_secure",
-                     "minimum_gateways",
-                     "prometheus_port"
-                     ]
+    exclude_from_hash = ["cluster_client_name",
+                         "logger_level"
+                         ]
 
     target_defaults = {"osd_op_timeout": 30,
                        "dataout_timeout": 20,
@@ -150,6 +146,7 @@ class Settings(object):
 
         self.error = False
         self.error_msg = ''
+        self._defined_settings = []
 
         config = ConfigParser()
         dataset = config.read(conffile)
@@ -194,6 +191,7 @@ class Settings(object):
             v = settings[k]
             v = self.normalize(k, settings[k])
 
+            self._defined_settings.append(k)
             self.__setattr__(k, v)
 
     def hash(self):
@@ -203,8 +201,9 @@ class Settings(object):
         """
 
         sync_settings = {}
-        for setting in Settings.sync_required:
-            sync_settings[setting] = getattr(self, setting)
+        for setting in self._defined_settings:
+            if setting not in Settings.exclude_from_hash:
+                sync_settings[setting] = getattr(self, setting)
 
         h = hashlib.sha256()
         h.update(json.dumps(sync_settings).encode('utf-8'))

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -5,7 +5,6 @@ import rados
 import rbd
 import re
 import datetime
-import hashlib
 import os
 
 import ceph_iscsi_config.settings as settings
@@ -282,30 +281,6 @@ def this_host():
     return the local machine's shortname
     """
     return socket.gethostname().split('.')[0]
-
-
-def gen_file_hash(filename, hash_type='sha256'):
-    """
-    generate a hash(default sha256) of a file and return the result
-    :param filename: filename to generate the checksum for
-    :param hash_type: type of checksum to generate
-    :return: checkum (str)
-    """
-
-    if (hash_type not in ['sha1', 'sha256', 'sha512', 'md5'] or not
-            os.path.exists(filename)):
-        return ''
-
-    hash_function = getattr(hashlib, hash_type)
-    h = hash_function()
-
-    with open(filename, 'rb') as file_in:
-        chunk = 0
-        while chunk != b'':
-            chunk = file_in.read(1024)
-            h.update(chunk)
-
-    return h.hexdigest()
 
 
 def encryption_available():

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -11,7 +11,7 @@ from rtslib_fb.utils import normalize_wwn, RTSLibError
 
 from ceph_iscsi_config.client import GWClient
 import ceph_iscsi_config.settings as settings
-from ceph_iscsi_config.utils import (resolve_ip_addresses, gen_file_hash,
+from ceph_iscsi_config.utils import (resolve_ip_addresses,
                                      CephiSCSIError)
 
 __author__ = 'Paul Cuzner'
@@ -122,7 +122,7 @@ def valid_gateway(target_iqn, gw_name, gw_ip, config):
                               api.response.status_code))
 
     # compare the hash of the new gateways conf file with the local one
-    local_hash = gen_file_hash('/etc/ceph/iscsi-gateway.cfg')
+    local_hash = settings.config.hash()
     try:
         remote_hash = str(api.response.json()['data'])
     except Exception:

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -33,7 +33,7 @@ from ceph_iscsi_config.lun import RBDDev, LUN
 from ceph_iscsi_config.client import GWClient, CHAP
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.utils import (normalize_ip_literal, resolve_ip_addresses,
-                                     ip_addresses, gen_file_hash, read_os_release,
+                                     ip_addresses, read_os_release,
                                      format_lio_yes_no, CephiSCSIError)
 
 from gwcli.utils import (this_host, APIRequest, valid_gateway, valid_client,
@@ -181,7 +181,7 @@ def get_sys_info(query_type=None):
 
     elif query_type == 'checkconf':
 
-        local_hash = gen_file_hash('/etc/ceph/iscsi-gateway.cfg')
+        local_hash = settings.config.hash()
         return jsonify(data=local_hash), 200
 
     elif query_type == 'checkversions':


### PR DESCRIPTION
Only some settings are required to be in sync between gateways so, instead of forcing the whole config file to be the same in all gateways, this PR will only consider the settings that really have to be in sync.

With this PR will be possible, for instance, to have different `cluster_client_name` on each gateway.

Signed-off-by: Ricardo Marques <rimarques@suse.com>