### PR TITLE
Fix spec for RHEL 8 builds

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -75,7 +75,7 @@ Requires:       python3-configshell >= 1.1.fb25
 %endif
 %endif
 
-%if 0%{?rhel} == 7
+%if 0%{?rhel}
 BuildRequires: systemd
 %else
 BuildRequires: systemd-rpm-macros


### PR DESCRIPTION
systemd-rpm-macros was recently broken off from systemd into its own
package. It is in Fedora but not yet in RHEL 8. This checks for RHELs
less than 8 assuming that in RHEL 9 we will have syncd up with fedora
and will have systemd-rpm-macros.