### PR TITLE
Handle the case where FQDN is the same as hostname

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -328,15 +328,15 @@ class Config(object):
                 gateways_config = self.config['gateways']
                 gateway_config = gateways_config.get(this_shortname)
                 if gateway_config:
-                    gateways_config[this_fqdn] = gateway_config
                     gateways_config.pop(this_shortname)
+                    gateways_config[this_fqdn] = gateway_config
                     self.update_item("gateways", None, gateways_config)
                 for target_iqn, target in self.config['targets'].items():
                     portals_config = target['portals']
                     portal_config = portals_config.get(this_shortname)
                     if portal_config:
-                        portals_config[this_fqdn] = portal_config
                         portals_config.pop(this_shortname)
+                        portals_config[this_fqdn] = portal_config
                         self.update_item("targets", target_iqn, target)
                 for disk_id, disk in self.config['disks'].items():
                     if disk.get('allocating_host') == this_shortname:


### PR DESCRIPTION
The upgrade from config version 9 to 10 might result in the
removal of all gateways if the gateway FQDNs are the same as
the hostnames.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>