### PR TITLE
Validate controls min/max value

### DIFF
--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -24,6 +24,36 @@ def init():
 class Settings(object):
     LIO_YES_NO_SETTINGS = ["immediate_data", "initial_r2t"]
 
+    LIO_INT_SETTINGS_LIMITS = {
+        "cmdsn_depth": {
+            "min": 1, "max": 512},
+        "dataout_timeout": {
+            "min": 2, "max": 60},
+        "nopin_response_timeout": {
+            "min": 3, "max": 60},
+        "nopin_timeout": {
+            "min": 3, "max": 60},
+        "first_burst_length": {
+            "min": 512, "max": 16777215},
+        "max_burst_length": {
+            "min": 512, "max": 16777215},
+        "max_outstanding_r2t": {
+            "min": 1, "max": 65535},
+        "max_recv_data_segment_length": {
+            "min": 512, "max": 16777215},
+        "max_xmit_data_segment_length": {
+            "min": 512, "max": 16777215},
+
+        "qfull_timeout": {
+            "min": 0, "max": 600},
+        "hw_max_sectors": {
+            "min": 1, "max": 8192},
+        "max_data_area_mb": {
+            "min": 1, "max": 2048},
+        "osd_op_timeout": {
+            "min": 0, "max": 600}
+    }
+
     _float_regex = re.compile(r"^[0-9]*\.{1}[0-9]$")
     _int_regex = re.compile(r"^[0-9]+$")
 
@@ -56,7 +86,14 @@ class Settings(object):
                     value = int(raw_value)
                 except ValueError:
                     raise ValueError("expected integer for {}".format(key))
-
+                limits = Settings.LIO_INT_SETTINGS_LIMITS.get(key)
+                if limits is not None:
+                    min = limits.get('min')
+                    if min is not None and value < min:
+                        raise ValueError("expected integer >= {} for {}".format(min, key))
+                    max = limits.get('max')
+                    if max is not None and value > max:
+                        raise ValueError("expected integer <= {} for {}".format(max, key))
             controls[key] = value
 
         return controls

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2361,27 +2361,36 @@ def get_settings():
     """
 
     target_default_controls = {}
+    target_controls_limits = {}
     settings_list = GWTarget.SETTINGS
     for k in settings_list:
         default_val = getattr(settings.config, k, None)
         if k in settings.Settings.LIO_YES_NO_SETTINGS:
             default_val = format_lio_yes_no(default_val)
+        elif k in settings.Settings.LIO_INT_SETTINGS_LIMITS:
+            target_controls_limits[k] = settings.Settings.LIO_INT_SETTINGS_LIMITS[k]
         target_default_controls[k] = default_val
 
     disk_default_controls = {}
+    disk_controls_limits = {}
     required_rbd_features = {}
     unsupported_rbd_features = {}
     for backstore, ks in LUN.SETTINGS.items():
         disk_default_controls[backstore] = {}
+        disk_controls_limits[backstore] = {}
         for k in ks:
             default_val = getattr(settings.config, k, None)
             disk_default_controls[backstore][k] = default_val
+            if k in settings.Settings.LIO_INT_SETTINGS_LIMITS:
+                disk_controls_limits[backstore][k] = settings.Settings.LIO_INT_SETTINGS_LIMITS[k]
         required_rbd_features[backstore] = RBDDev.required_features(backstore)
         unsupported_rbd_features[backstore] = RBDDev.unsupported_features(backstore)
 
     return jsonify({
         'target_default_controls': target_default_controls,
+        'target_controls_limits': target_controls_limits,
         'disk_default_controls': disk_default_controls,
+        'disk_controls_limits': disk_controls_limits,
         'unsupported_rbd_features': unsupported_rbd_features,
         'required_rbd_features': required_rbd_features,
         'backstores': LUN.BACKSTORES,

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import unittest
+
+from ceph_iscsi_config.settings import Settings
+from ceph_iscsi_config.target import GWTarget
+
+
+class SettingsTest(unittest.TestCase):
+
+    @staticmethod
+    def _normalize(controls):
+        return Settings.normalize_controls(controls, GWTarget.SETTINGS)
+
+    def test_normalize_controls_int(self):
+        self.assertEqual(
+            SettingsTest._normalize({'dataout_timeout': 3}), {'dataout_timeout': 3})
+        self.assertEqual(
+            SettingsTest._normalize({'dataout_timeout': '3'}), {'dataout_timeout': 3})
+
+        with self.assertRaises(ValueError) as cm:
+            SettingsTest._normalize({'dataout_timeout': 1})
+        self.assertEqual('expected integer >= 2 for dataout_timeout', str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            SettingsTest._normalize({'dataout_timeout': 64})
+        self.assertEqual('expected integer <= 60 for dataout_timeout', str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            SettingsTest._normalize({'dataout_timeout': '64'})
+        self.assertEqual('expected integer <= 60 for dataout_timeout', str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            SettingsTest._normalize({'dataout_timeout': 'abc'})
+        self.assertEqual('expected integer for dataout_timeout', str(cm.exception))
+
+    def test_normalize_controls_yes_no(self):
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'Yes'}), {'immediate_data': True})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'yes'}), {'immediate_data': True})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': True}), {'immediate_data': True})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'True'}), {'immediate_data': True})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'true'}), {'immediate_data': True})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': '1'}), {'immediate_data': True})
+
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'No'}), {'immediate_data': False})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'no'}), {'immediate_data': False})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': False}), {'immediate_data': False})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'False'}), {'immediate_data': False})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': 'false'}), {'immediate_data': False})
+        self.assertEqual(
+            SettingsTest._normalize({'immediate_data': '0'}), {'immediate_data': False})
+
+        with self.assertRaises(ValueError) as cm:
+            SettingsTest._normalize({'immediate_data': 'abc'})
+        self.assertEqual('expected yes or no for immediate_data', str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            SettingsTest._normalize({'immediate_data': 123})
+        self.assertEqual('expected yes or no for immediate_data', str(cm.exception))


### PR DESCRIPTION
This PR will validate if control values meet the requirements described in PR https://github.com/ceph/ceph-iscsi-cli/pull/147:

![Screenshot from 2019-07-09 14-31-23](https://user-images.githubusercontent.com/14297426/60895574-ce19d080-a25c-11e9-81e9-652241062697.png)

Additionally, the limits for each control are now returned by the API so REST consumers like Ceph Dashboard can validate the inputs beforehand (https://github.com/ceph/ceph/pull/28942).

Signed-off-by: Ricardo Marques <rimarques@suse.com>