### PR TITLE
Fix blacklist cleanup error handling

### DIFF
--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -40,7 +40,7 @@ class CephiSCSIGateway(object):
                                                 client_name=conf.cluster_client_name,
                                                 cephconf=conf.cephconf),
                                          stderr=subprocess.STDOUT, shell=True)
-        if "un-blacklisting" in result:
+        if ("un-blacklisting" in result) or ("isn't blacklisted" in result):
             self.logger.info("Successfully removed blacklist entry")
             return True
         else:


### PR DESCRIPTION
It is possible that between the time we do a

ceph osd blacklist ls

call and while we are deleting our blacklist entries an entry can
expire. In this case do not exit with error.