### PR TITLE
Fix ipv6 resolutions

### DIFF
--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -82,13 +82,13 @@ def resolve_ip_addresses(addr):
             pass
 
     addrs = set()
-    for family in families:
-        try:
-            infos = socket.getaddrinfo(addr, 0, family)
-            for info in infos:
+    try:
+        infos = socket.getaddrinfo(addr, 0)
+        for info in infos:
+            if info[0] in families:
                 addrs.add(info[4][0])
-        except Exception:
-            pass
+    except Exception:
+        pass
 
     return list(addrs)
 


### PR DESCRIPTION
When we added ipv6 support we added a call:

socket.getaddrinfo(....socket.AF_INET6)

Some configs might not have ipv6 name resolutions setup correctly so
this causes us to have to wait for a timeout for every REST api call.

In some situations it may not be possible to fix DNS, so this just has
us use socket.getaddrinfo with no faimily then loop over the returned
adds and check for the specific familys we support. It is going to be a
little less efficient, but we will normnally only get AF_INET and
AF_INET6 addresses.