### PR TITLE
Target level CHAP authentication and TPG lun_id persistence

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -307,7 +307,8 @@ class GWClient(GWObject):
 
             client.manage('present')  # ensure the client exists
 
-    def try_disable_auth(self, tpg):
+    @staticmethod
+    def try_disable_auth(tpg):
         """
         Disable authentication (enable ACL mode) if this is the last CHAP user.
 
@@ -318,6 +319,9 @@ class GWClient(GWObject):
         for client in tpg.node_acls:
             if client.chap_userid or client.chap_password:
                 return
+
+        if tpg.chap_userid or tpg.chap_password:
+            return
 
         tpg.set_attribute('authentication', '0')
 
@@ -371,7 +375,7 @@ class GWClient(GWObject):
             if auth_enabled:
                 self.tpg.set_attribute('authentication', '1')
             else:
-                self.try_disable_auth(self.tpg)
+                GWClient.try_disable_auth(self.tpg)
 
             self.logger.debug("Updating config object meta data")
             encryption_enabled = encryption_available()
@@ -485,7 +489,7 @@ class GWClient(GWObject):
 
         try:
             self.acl.delete()
-            self.try_disable_auth(self.tpg)
+            GWClient.try_disable_auth(self.tpg)
             self.change_count += 1
             self.logger.info("(Client.delete) deleted NodeACL for "
                              "{}".format(self.iqn))

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -364,6 +364,12 @@ class Config(object):
                     'mutual_password': '',
                     'mutual_password_encryption_enabled': False
                 }
+                disks = {}
+                for disk_index, disk in enumerate(sorted(target['disks'])):
+                    disks[disk] = {
+                        'lun_id': disk_index
+                    }
+                target['disks'] = disks
                 self.update_item("targets", target_iqn, target)
             self.update_item("version", None, 11)
 

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -56,7 +56,7 @@ class Config(object):
                                       'mutual_username': '',
                                       'mutual_password': '',
                                       'mutual_password_encryption_enabled': False},
-                   "version": 10,
+                   "version": 11,
                    "epoch": 0,
                    "created": '',
                    "updated": ''
@@ -353,6 +353,19 @@ class Config(object):
             else:
                 self.del_item("gateways_upgraded", None)
                 self.update_item("version", None, 10)
+
+        if self.config['version'] == 10:
+            for target_iqn, target in self.config['targets'].items():
+                target['auth'] = {
+                    'username': '',
+                    'password': '',
+                    'password_encryption_enabled': False,
+                    'mutual_username': '',
+                    'mutual_password': '',
+                    'mutual_password_encryption_enabled': False
+                }
+                self.update_item("targets", target_iqn, target)
+            self.update_item("version", None, 11)
 
         self.commit("retain")
 

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -356,7 +356,7 @@ class CephiSCSIGateway(object):
                 if not target_config['portals']:
                     # Last gw for the target so delete everything that lives
                     # under the tpg in LIO since we can't create it
-                    target_config['disks'] = []
+                    target_config['disks'] = {}
                     target_config['clients'] = {}
                     target_config['controls'] = {}
                     target_config['groups'] = {}

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -251,6 +251,13 @@ def valid_client(**kwargs):
             return ("A client with the name '{}' is "
                     "already defined".format(client_iqn))
 
+        # Mixing TPG/target auth with ACL is not supported
+        target_username = target_config['auth']['username']
+        target_password = target_config['auth']['password']
+        target_auth_enabled = (target_username and target_password)
+        if target_auth_enabled:
+            return "Cannot create client because target CHAP authentication is enabled"
+
         # Creates can only be done with a minimum number of gw's in place
         num_gws = len([gw_name for gw_name in config['gateways']
                        if isinstance(config['gateways'][gw_name], dict)])

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -33,7 +33,7 @@ from ceph_iscsi_config.lun import RBDDev, LUN
 from ceph_iscsi_config.client import GWClient, CHAP
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.utils import (normalize_ip_literal, resolve_ip_addresses,
-                                     ip_addresses, read_os_release,
+                                     ip_addresses, read_os_release, encryption_available,
                                      format_lio_yes_no, CephiSCSIError, this_host)
 
 from gwcli.utils import (APIRequest, valid_gateway, valid_client,
@@ -520,6 +520,15 @@ def get_config():
                         discovery_auth_config['mutual_password_encryption_enabled'])
             discovery_auth_config['mutual_password'] = chap.password
             for _, target in result_config['targets'].items():
+                target_auth_config = target['auth']
+                chap = CHAP(target_auth_config['username'],
+                            target_auth_config['password'],
+                            target_auth_config['password_encryption_enabled'])
+                target_auth_config['password'] = chap.password
+                chap = CHAP(target_auth_config['mutual_username'],
+                            target_auth_config['mutual_password'],
+                            target_auth_config['mutual_password_encryption_enabled'])
+                target_auth_config['mutual_password'] = chap.password
                 for _, client in target['clients'].items():
                     auth_config = client['auth']
                     chap = CHAP(auth_config['username'],
@@ -1561,9 +1570,19 @@ def _discoveryauth():
 @requires_restricted_auth
 def targetauth(target_iqn=None):
     """
-    Coordinate the gen-acls across each gateway node
+    Coordinate the gen-acls or CHAP/MUTUAL_CHAP across each gateway node
     :param target_iqn: (str) IQN of the target
     :param action: (str) action to be performed
+    :param username: (str) username string is 8-64 chars long containing any alphanumeric in
+                           [0-9a-zA-Z] and '.' ':' '@' '_' '-'
+    :param password: (str) password string is 12-16 chars long containing any alphanumeric in
+                           [0-9a-zA-Z] and '@' '-' '_' '/'
+    :param mutual_username: (str) mutual_username string is 8-64 chars long containing any
+                            alphanumeric in
+                            [0-9a-zA-Z] and '.' ':' '@' '_' '-'
+    :param mutual_password: (str) mutual_password string is 12-16 chars long containing any
+                            alphanumeric in
+                            [0-9a-zA-Z] and '@' '-' '_' '/'
     **RESTRICTED**
     Examples:
     curl --insecure --user admin:admin -d auth='disable_acl'
@@ -1571,7 +1590,7 @@ def targetauth(target_iqn=None):
     """
 
     action = request.form.get('action')
-    if action not in ['disable_acl', 'enable_acl']:
+    if action and action not in ['disable_acl', 'enable_acl']:
         return jsonify(message='Invalid auth {}'.format(action)), 400
 
     target_config = config.config['targets'][target_iqn]
@@ -1579,6 +1598,30 @@ def targetauth(target_iqn=None):
     if action == 'disable_acl' and target_config['clients'].keys():
         return jsonify(message='Cannot disable ACL authentication '
                                'because target has clients'), 400
+
+    # Mixing TPG/target auth with ACL is not supported
+    if action == 'enable_acl':
+        target_username = target_config['auth']['username']
+        target_password = target_config['auth']['password']
+        target_auth_enabled = (target_username and target_password)
+        if target_auth_enabled:
+            return jsonify(message="Cannot enable ACL authentication "
+                                   "because target CHAP authentication is enabled"), 400
+
+    username = request.form.get('username', '')
+    password = request.form.get('password', '')
+    mutual_username = request.form.get('mutual_username', '')
+    mutual_password = request.form.get('mutual_password', '')
+
+    # Mixing TPG/target auth with ACL is not supported
+    auth_enabled = (username and password)
+    if auth_enabled and target_config['acl_enabled']:
+        return jsonify(message="Cannot enable target CHAP authentication "
+                               "because ACL authentication is enabled"), 400
+
+    error_msg = valid_credentials(username, password, mutual_username, mutual_password)
+    if error_msg:
+        return jsonify(message=error_msg), 400
 
     try:
         gateways = get_remote_gateways(target_config['portals'], logger)
@@ -1590,7 +1633,11 @@ def targetauth(target_iqn=None):
     # Apply to all gateways
     api_vars = {
         "committing_host": local_gw,
-        "action": action
+        "action": action,
+        "username": username,
+        "password": password,
+        "mutual_username": mutual_username,
+        "mutual_password": mutual_password,
     }
     resp_text, resp_code = call_api(gateways, '_targetauth',
                                     target_iqn,
@@ -1604,7 +1651,7 @@ def targetauth(target_iqn=None):
 @requires_restricted_auth
 def _targetauth(target_iqn=None):
     """
-    Apply gen-acls on the local gateway
+    Apply gen-acls or CHAP/MUTUAL_CHAP on the local gateway
     Internal Use ONLY
     **RESTRICTED**
     """
@@ -1613,19 +1660,49 @@ def _targetauth(target_iqn=None):
 
     local_gw = this_host()
     committing_host = request.form['committing_host']
-    action = request.form['action']
+    action = request.form.get('action')
+    username = request.form['username']
+    password = request.form['password']
+    mutual_username = request.form['mutual_username']
+    mutual_password = request.form['mutual_password']
 
     target = GWTarget(logger, target_iqn, [])
 
-    acl_enabled = (action == 'enable_acl')
+    target_config = config.config['targets'][target_iqn]
 
     if target.exists():
         target.load_config()
-        target.update_acl(acl_enabled)
+        if action in ['disable_acl', 'enable_acl']:
+            acl_enabled = (action == 'enable_acl')
+            target.update_acl(acl_enabled)
+        else:
+            tpg = target.get_tpg_by_gateway_name(local_gw)
+            target.update_auth(tpg, username, password,
+                               mutual_username, mutual_password)
 
     if committing_host == local_gw:
-        target_config = config.config['targets'][target_iqn]
-        target_config['acl_enabled'] = acl_enabled
+        if action in ['disable_acl', 'enable_acl']:
+            acl_enabled = (action == 'enable_acl')
+            target_config['acl_enabled'] = acl_enabled
+        else:
+            encryption_enabled = encryption_available()
+            auth_config = {
+                'username': '',
+                'password': '',
+                'password_encryption_enabled': encryption_enabled,
+                'mutual_username': '',
+                'mutual_password': '',
+                'mutual_password_encryption_enabled': encryption_enabled
+            }
+            if username != '':
+                chap = CHAP(username, password, encryption_enabled)
+                chap_mutual = CHAP(mutual_username, mutual_password, encryption_enabled)
+                auth_config['username'] = chap.user
+                auth_config['password'] = chap.encrypted_password(encryption_enabled)
+                auth_config['mutual_username'] = chap_mutual.user
+                auth_config['mutual_password'] = chap_mutual.encrypted_password(encryption_enabled)
+            target_config['auth'] = auth_config
+
         config.update_item('targets', target_iqn, target_config)
         config.commit("retain")
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -227,9 +227,11 @@ class ChapTest(unittest.TestCase):
                     "nopin_response_timeout": 17
                 },
                 "created": "2018/12/07 09:19:01",
-                "disks": [
-                    "rbd/disk_1"
-                ],
+                "disks": {
+                    "rbd/disk_1": {
+                        "lun_id": 0
+                    }
+                },
                 "groups": {
                     "mygroup": {
                         "disks": {

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -214,6 +214,14 @@ class ChapTest(unittest.TestCase):
                     }
                 },
                 "acl_enabled": True,
+                "auth": {
+                    "username": "",
+                    "password": "",
+                    "password_encryption_enabled": False,
+                    "mutual_username": "",
+                    "mutual_password": "",
+                    "mutual_password_encryption_enabled": False
+                },
                 "controls": {
                     "immediate_data": False,
                     "nopin_response_timeout": 17
@@ -266,5 +274,5 @@ class ChapTest(unittest.TestCase):
             }
         },
         "updated": "2018/12/07 09:18:13",
-        "version": 10
+        "version": 11
     }


### PR DESCRIPTION
This PR contains 2 different commits to fix both topics discussed on issue https://github.com/ceph/ceph-iscsi/issues/130

**1. Target level CHAP authentication**
It's now possible to define CHAP/MUTUAL_CHAP authentication at the target level (same credentials are applied to all TPGs).
When using ACL, those credentials will be inherited and can be overridden at the client level.

**2. Persist TPG lun_id**
Instead of relying on storage object path to generate it, TPG `lun_id` will now be persisted in the `gateway.conf` ensuring that the TPG `lun_id` is the same in all gateways, and will not change across restarts.

Fixes https://github.com/ceph/ceph-iscsi/issues/130