### PR TITLE
ceph-iscsi settings cleanup

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -12,6 +12,7 @@ from rtslib_fb.utils import RTSLibError, RTSLibNotInCFS, normalize_wwn
 
 import ceph_iscsi_config.settings as settings
 
+from ceph_iscsi_config.gateway_setting import CLIENT_SETTINGS
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.utils import encryption_available, CephiSCSIError, this_host
 from ceph_iscsi_config.gateway_object import GWObject
@@ -21,10 +22,7 @@ class GWClient(GWObject):
     """
     This class holds a representation of a client connecting to LIO
     """
-    SETTINGS = ["dataout_timeout",
-                "nopin_response_timeout",
-                "nopin_timeout",
-                "cmdsn_depth"]
+    SETTINGS = CLIENT_SETTINGS
 
     seed_metadata = {"auth": {"username": '',
                               "password": '',

--- a/ceph_iscsi_config/gateway_object.py
+++ b/ceph_iscsi_config/gateway_object.py
@@ -5,7 +5,6 @@ from ceph_iscsi_config.utils import CephiSCSIError
 
 class GWObject(object):
     def __init__(self, cfg_type, cfg_type_key, logger, control_settings):
-        self.control_settings = control_settings
         self.cfg_type = cfg_type
         self.cfg_type_key = cfg_type_key
         self.logger = logger
@@ -17,7 +16,7 @@ class GWObject(object):
         # Copy of controls that will not be written until commit is called.
         # To update the kernel call the child object's update function.
         self.controls = self._get_config_controls().copy()
-        self._add_properies()
+        self._add_properies(control_settings)
 
     def _set_config_controls(self, config, controls):
         config.config[self.cfg_type][self.cfg_type_key]['controls'] = controls
@@ -30,25 +29,23 @@ class GWObject(object):
         else:
             return {}
 
-    def _get_control(self, key):
+    def _get_control(self, key, setting):
         value = self.controls.get(key, None)
-        if value is not None:
-            value = settings.Settings.normalize(key, value)
         if value is None:
             return getattr(settings.config, key)
-        return value
+
+        return setting.normalize(value)
 
     def _set_control(self, key, value):
-        if value is None or \
-           settings.Settings.normalize(key, value) == getattr(settings.config, key):
+        if value is None or value == getattr(settings.config, key):
             self.controls.pop(key, None)
         else:
             self.controls[key] = value
 
-    def _add_properies(self):
-        for k in self.control_settings:
+    def _add_properies(self, control_settings):
+        for k, setting in control_settings.items():
             setattr(GWObject, k,
-                    property(lambda self, k=k: self._get_control(k),
+                    property(lambda self, k=k, s=setting: self._get_control(k, s),
                              lambda self, v, k=k: self._set_control(k, v)))
 
     def update_controls(self):

--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -1,0 +1,202 @@
+import logging
+
+
+def convert_str_to_bool(value):
+    """
+    Convert true/false/yes/no/1/0 to boolean
+    """
+
+    if isinstance(value, bool):
+        return value
+
+    value = str(value).lower()
+    if value in ['1', 'true', 'yes']:
+        return True
+    elif value in ['0', 'false', 'no']:
+        return False
+    raise ValueError(value)
+
+
+class Setting(object):
+    def __init__(self, name, type_str, def_val):
+        self.name = name
+        self.type_str = type_str
+        self.def_val = def_val
+
+    def __contains__(self, key):
+        return key == self.def_val
+
+
+class BoolSetting(Setting):
+    def __init__(self, name, def_val):
+        super(BoolSetting, self).__init__(name, "bool", def_val)
+
+    def to_str(self, norm_val):
+        if norm_val:
+            return "true"
+        else:
+            return "false"
+
+    def normalize(self, raw_val):
+        try:
+            # for compat we also support Yes/No and 1/0
+            return convert_str_to_bool(raw_val)
+        except ValueError:
+            raise ValueError("expected true or false for {}".format(self.name))
+
+
+class LIOBoolSetting(BoolSetting):
+    def __init__(self, name, def_val):
+        super(LIOBoolSetting, self).__init__(name, def_val)
+
+    def to_str(self, norm_val):
+        if norm_val:
+            return "yes"
+        else:
+            return "no"
+
+    def normalize(self, raw_val):
+        try:
+            # for compat we also support True/False and 1/0
+            return convert_str_to_bool(raw_val)
+        except ValueError:
+            raise ValueError("expected yes or no for {}".format(self.name))
+
+
+class ListSetting(Setting):
+    def __init__(self, name, def_val):
+        super(ListSetting, self).__init__(name, "list", def_val)
+
+    def to_str(self, norm_val):
+        return str(norm_val)
+
+    def normalize(self, raw_val):
+        return raw_val.split(',') if raw_val else []
+
+
+class StrSetting(Setting):
+    def __init__(self, name, def_val):
+        super(StrSetting, self).__init__(name, "str", def_val)
+
+    def to_str(self, norm_val):
+        return str(norm_val)
+
+    def normalize(self, raw_val):
+        return str(raw_val)
+
+
+class IntSetting(Setting):
+    def __init__(self, name, min_val, max_val, def_val):
+        self.min_val = min_val
+        self.max_val = max_val
+        super(IntSetting, self).__init__(name, "int", def_val)
+
+    def to_str(self, norm_val):
+        return str(norm_val)
+
+    def normalize(self, raw_val):
+        try:
+            val = int(raw_val)
+        except ValueError:
+            raise ValueError("expected integer for {}".format(self.name))
+
+        if val < self.min_val:
+            raise ValueError("expected integer >= {} for {}".
+                             format(self.min_val, self.name))
+        if val > self.max_val:
+            raise ValueError("expected integer <= {} for {}".
+                             format(self.max_val, self.name))
+        return val
+
+
+class EnumSetting(Setting):
+    def __init__(self, name, valid_vals, def_val):
+        if len(valid_vals) == 0:
+            raise ValueError("Invalid enum. There must be at least one valid value.")
+
+        valid_type = type(valid_vals[0])
+        if valid_type is not int and valid_type is not str:
+            raise ValueError("Invalid enum. Items must be str or int. Got {}".
+                             format(valid_type))
+
+        for i in valid_vals:
+            if valid_type != type(i):
+                raise ValueError("Invalid enum. All items must be the same type."
+                                 "Found {} and {}".format(type(i), valid_type))
+
+        self.valid_vals = valid_vals
+        super(EnumSetting, self).__init__(name, "enum", def_val)
+
+    def to_str(self, norm_val):
+        return str(norm_val)
+
+    def normalize(self, raw_val):
+        if isinstance(self.valid_vals[0], str):
+            val = str(raw_val)
+        else:
+            val = int(raw_val)
+
+        if val not in self.valid_vals:
+            raise ValueError("expected {} for {} found {}".
+                             format(self.valid_vals, self.name, raw_val))
+
+        return val
+
+
+CLIENT_SETTINGS = {
+    "dataout_timeout": IntSetting("dataout_timeout", 2, 60, 20),
+    "nopin_response_timeout": IntSetting("nopin_response_timeout", 3, 60, 5),
+    "nopin_timeout": IntSetting("nopin_timeout", 3, 60, 5),
+    "cmdsn_depth": IntSetting("cmdsn_depth", 1, 512, 128)}
+
+TGT_SETTINGS = {
+    # client settings you can also set at the ceph-iscsi target level
+    "dataout_timeout": IntSetting("dataout_timeout", 2, 60, 20),
+    "nopin_response_timeout": IntSetting("nopin_response_timeout", 3, 60, 5),
+    "nopin_timeout": IntSetting("nopin_timeout", 3, 60, 5),
+    "cmdsn_depth": IntSetting("cmdsn_depth", 1, 512, 128),
+    # lio tpg settings
+    "immediate_data": LIOBoolSetting("immediate_data", True),
+    "initial_r2t": LIOBoolSetting("initial_r2t", True),
+    "max_outstanding_r2t": IntSetting("max_outstanding_r2t", 1, 65535, 1),
+    "first_burst_length": IntSetting("first_burst_length", 512, 16777215, 262144),
+    "max_burst_length": IntSetting("max_burst_length", 512, 16777215, 524288),
+    "max_recv_data_segment_length": IntSetting("max_recv_data_segment_length",
+                                               512, 16777215, 262144),
+    "max_xmit_data_segment_length": IntSetting("max_xmit_data_segment_length",
+                                               512, 16777215, 262144)}
+
+SYS_SETTINGS = {
+    "cluster_name": StrSetting("cluster_name", "ceph"),
+    "pool": StrSetting("pool", "rbd"),
+    "cluster_client_name": StrSetting("cluster_client_name", "client.admin"),
+    "time_out": IntSetting("time_out", 1, 600, 30),
+    "api_host": StrSetting("api_host", "::"),
+    "api_port": IntSetting("api_port", 1, 65535, 5000),
+    "api_secure": BoolSetting("api_secure", True),
+    "api_ssl_verify": BoolSetting("api_ssl_verify", False),
+    "loop_delay": IntSetting("loop_delay", 1, 60, 2),
+    "trusted_ip_list": ListSetting("trusted_ip_list", []),  # comma separate list of IPs
+    "api_user": StrSetting("api_user", "admin"),
+    "api_password": StrSetting("api_password", "admin"),
+    "ceph_user": StrSetting("ceph_user", "admin"),
+    "debug": BoolSetting("debug", False),
+    "minimum_gateways": IntSetting("minimum_gateways", 2, 9999, 2),
+    "ceph_config_dir": StrSetting("ceph_config_dir", '/etc/ceph'),
+    "priv_key": StrSetting("priv_key", 'iscsi-gateway.key'),
+    "pub_key": StrSetting("pub_key", 'iscsi-gateway-pub.key'),
+    "prometheus_exporter": BoolSetting("prometheus_exporter", True),
+    "prometheus_port": IntSetting("prometheus_port", 1, 65535, 9287),
+    "prometheus_host": StrSetting("prometheus_host", "::"),
+    "logger_level": IntSetting("logger_level", logging.DEBUG, logging.CRITICAL,
+                               logging.DEBUG),
+    # TODO: This is under sys for compat. It is not settable per device/backend
+    # type yet.
+    "alua_failover_type": EnumSetting("alua_failover_type",
+                                      ["implicit", "explicit"], "implicit")}
+
+TCMU_SETTINGS = {
+    "max_data_area_mb": IntSetting("max_data_area_mb", 1, 2048, 8),
+    "qfull_timeout": IntSetting("qfull_timeout", 0, 600, 5),
+    "osd_op_timeout": IntSetting("osd_op_timeout", 0, 600, 30),
+    "hw_max_sectors": IntSetting("hw_max_sectors", 1, 8192, 1024)}

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -9,6 +9,7 @@ from rtslib_fb.utils import RTSLibError
 
 import ceph_iscsi_config.settings as settings
 
+from ceph_iscsi_config.gateway_setting import TCMU_SETTINGS
 from ceph_iscsi_config.backstore import USER_RBD
 from ceph_iscsi_config.utils import (convert_2_bytes, gen_control_string,
                                      valid_size, get_pool_id, ip_addresses,
@@ -285,12 +286,7 @@ class LUN(GWObject):
     DEFAULT_BACKSTORE = USER_RBD
 
     SETTINGS = {
-        USER_RBD: [
-            "max_data_area_mb",
-            "qfull_timeout",
-            "osd_op_timeout",
-            "hw_max_sectors"
-        ]
+        USER_RBD: TCMU_SETTINGS
     }
 
     def __init__(self, logger, pool, image, size, allocating_host,

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -5,12 +5,13 @@ try:
     from ConfigParser import ConfigParser
 except ImportError:
     from configparser import ConfigParser
-from distutils.util import strtobool
 
 import hashlib
 import json
-import logging
 import re
+
+from ceph_iscsi_config.gateway_setting import (TGT_SETTINGS, SYS_SETTINGS,
+                                               TCMU_SETTINGS)
 
 
 # this module when imported preserves the global values
@@ -22,38 +23,6 @@ def init():
 
 
 class Settings(object):
-    LIO_YES_NO_SETTINGS = ["immediate_data", "initial_r2t"]
-
-    LIO_INT_SETTINGS_LIMITS = {
-        "cmdsn_depth": {
-            "min": 1, "max": 512},
-        "dataout_timeout": {
-            "min": 2, "max": 60},
-        "nopin_response_timeout": {
-            "min": 3, "max": 60},
-        "nopin_timeout": {
-            "min": 3, "max": 60},
-        "first_burst_length": {
-            "min": 512, "max": 16777215},
-        "max_burst_length": {
-            "min": 512, "max": 16777215},
-        "max_outstanding_r2t": {
-            "min": 1, "max": 65535},
-        "max_recv_data_segment_length": {
-            "min": 512, "max": 16777215},
-        "max_xmit_data_segment_length": {
-            "min": 512, "max": 16777215},
-
-        "qfull_timeout": {
-            "min": 0, "max": 600},
-        "hw_max_sectors": {
-            "min": 1, "max": 8192},
-        "max_data_area_mb": {
-            "min": 1, "max": 2048},
-        "osd_op_timeout": {
-            "min": 0, "max": 600}
-    }
-
     _float_regex = re.compile(r"^[0-9]*\.{1}[0-9]$")
     _int_regex = re.compile(r"^[0-9]+$")
 
@@ -66,145 +35,47 @@ class Settings(object):
         controls = {}
 
         for key, raw_value in raw_controls.items():
-            if key not in settings_list:
-                raise ValueError("Supported controls: {}".format(",".join(settings_list)))
+            setting = settings_list.get(key)
+            if setting is None:
+                raise ValueError("Supported controls: {}".format(",".join(settings_list.keys())))
 
             if raw_value in [None, '']:
                 # Use the default/reset.
                 controls[key] = None
                 continue
 
-            # Do not use normalize() because if the user inputs invalid
-            # values we want to pass up more detailed errors.
-            if key in Settings.LIO_YES_NO_SETTINGS:
-                try:
-                    value = Settings.convert_lio_yes_no(raw_value)
-                except ValueError:
-                    raise ValueError("expected yes or no for {}".format(key))
-            else:
-                try:
-                    value = int(raw_value)
-                except ValueError:
-                    raise ValueError("expected integer for {}".format(key))
-                limits = Settings.LIO_INT_SETTINGS_LIMITS.get(key)
-                if limits is not None:
-                    min = limits.get('min')
-                    if min is not None and value < min:
-                        raise ValueError("expected integer >= {} for {}".format(min, key))
-                    max = limits.get('max')
-                    if max is not None and value > max:
-                        raise ValueError("expected integer <= {} for {}".format(max, key))
-            controls[key] = value
+            controls[key] = setting.normalize(raw_value)
 
         return controls
-
-    @staticmethod
-    def convert_lio_yes_no(value):
-        """
-        Convert true/false/yes/no to boolean
-        """
-
-        value = str(value).lower()
-        if value in ['1', 'true', 'yes']:
-            return True
-        elif value in ['0', 'false', 'no']:
-            return False
-        raise ValueError(value)
-
-    @staticmethod
-    def normalize(k, v):
-        if k == 'trusted_ip_list':
-            v = v.split(',') if v else []
-
-        if k in Settings.LIO_YES_NO_SETTINGS:
-            try:
-                v = Settings.convert_lio_yes_no(v)
-            except Exception:
-                v = True
-        elif v in ['true', 'True', 'false', 'False']:
-            v = strtobool(v)
-
-        if isinstance(v, str):
-            # convert any strings that hold numbers to int/float
-            if Settings._float_regex.search(v):
-                v = float(v)
-
-            if Settings._int_regex.search(v):
-                v = int(v)
-        return v
-
-    defaults = {"cluster_name": "ceph",
-                "pool": "rbd",
-                "cluster_client_name": "client.admin",
-                "time_out": 30,
-                "api_host": "::",
-                "api_port": 5000,
-                "api_secure": "true",
-                "api_ssl_verify": "false",
-                "loop_delay": 2,
-                "trusted_ip_list": '',          # comma separate list of IPs
-                "api_user": "admin",
-                "api_password": "admin",
-                "ceph_user": "admin",
-                "debug": "false",
-                "minimum_gateways": 2,
-                "ceph_config_dir": '/etc/ceph',
-                "priv_key": 'iscsi-gateway.key',
-                "pub_key": 'iscsi-gateway-pub.key',
-                "prometheus_exporter": "true",
-                "prometheus_port": 9287,
-                "prometheus_host": "::",
-                "logger_level": logging.DEBUG
-                }
 
     exclude_from_hash = ["cluster_client_name",
                          "logger_level"
                          ]
 
-    target_defaults = {"osd_op_timeout": 30,
-                       "dataout_timeout": 20,
-                       "nopin_response_timeout": 5,
-                       "nopin_timeout": 5,
-                       "qfull_timeout": 5,
-                       "cmdsn_depth": 128,
-                       "immediate_data": "Yes",
-                       "initial_r2t": "Yes",
-                       "max_outstanding_r2t": 1,
-                       "first_burst_length": 262144,
-                       "max_burst_length": 524288,
-                       "max_recv_data_segment_length": 262144,
-                       "max_xmit_data_segment_length": 262144,
-                       "max_data_area_mb": 8,
-                       "alua_failover_type": "implicit",
-                       "hw_max_sectors": "1024"
-                       }
-
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):
 
         self.error = False
         self.error_msg = ''
-        self._defined_settings = []
 
         config = ConfigParser()
         dataset = config.read(conffile)
-        if len(dataset) == 0:
-            # no config file present, set up defaults
-            self._define_settings(Settings.defaults)
-            self._define_settings(Settings.target_defaults)
-        else:
+
+        self._add_attrs_from_defs(SYS_SETTINGS)
+        self._add_attrs_from_defs(TGT_SETTINGS)
+        self._add_attrs_from_defs(TCMU_SETTINGS)
+
+        if len(dataset) != 0:
             # If we have a file use it to override the defaults
             if config.has_section("config"):
-                runtime_settings = dict(Settings.defaults)
-                runtime_settings.update(dict(config.items("config")))
-                self._define_settings(runtime_settings)
+                self._override_attrs_from_conf(config.items("config"),
+                                               SYS_SETTINGS)
 
             if config.has_section("target"):
-                target_settings = dict(Settings.target_defaults)
-                target_settings.update(dict(config.items("target")))
-                self._define_settings(target_settings)
-            else:
-                # We always want these values set to at least the defaults.
-                self._define_settings(Settings.target_defaults)
+                all_settings = TGT_SETTINGS.copy()
+                all_settings.update(TCMU_SETTINGS)
+
+                self._override_attrs_from_conf(config.items("target"),
+                                               all_settings)
 
         self.cephconf = '{}/{}.conf'.format(self.ceph_config_dir, self.cluster_name)
         if self.api_secure:
@@ -216,20 +87,37 @@ class Settings(object):
             s += "{} = {}\n".format(k, self.__dict__[k])
         return s
 
-    def _define_settings(self, settings):
+    def _add_attrs_from_defs(self, def_settings):
+        """
+        receive a settings dict and apply those key/value to the
+        current instance, settings that look like numbers are converted
+        :param settings: array of setting objects
+        :return: None
+        """
+        for k, setting in def_settings.items():
+            self.__setattr__(k, setting.def_val)
+
+    def _override_attrs_from_conf(self, config, def_settings):
         """
         receive a settings dict and apply those key/value to the
         current instance, settings that look like numbers are converted
         :param settings: dict of settings
         :return: None
         """
+        for k, v in config:
+            if hasattr(self, k):
+                setting = def_settings[k]
+                try:
+                    self.__setattr__(k, setting.normalize(v))
+                except ValueError:
+                    # We do not even have the logger up yet, so just ignore
+                    # so the deamons can still start
+                    pass
 
-        for k in settings:
-            v = settings[k]
-            v = self.normalize(k, settings[k])
-
-            self._defined_settings.append(k)
-            self.__setattr__(k, v)
+    def _hash_settings(self, def_settings, sync_settings):
+        for setting in def_settings:
+            if setting not in Settings.exclude_from_hash:
+                sync_settings[setting] = getattr(self, setting)
 
     def hash(self):
         """
@@ -238,9 +126,9 @@ class Settings(object):
         """
 
         sync_settings = {}
-        for setting in self._defined_settings:
-            if setting not in Settings.exclude_from_hash:
-                sync_settings[setting] = getattr(self, setting)
+        self._hash_settings(SYS_SETTINGS.keys(), sync_settings)
+        self._hash_settings(TGT_SETTINGS.keys(), sync_settings)
+        self._hash_settings(TCMU_SETTINGS.keys(), sync_settings)
 
         h = hashlib.sha256()
         h.update(json.dumps(sync_settings).encode('utf-8'))

--- a/ceph_iscsi_config/target.py
+++ b/ceph_iscsi_config/target.py
@@ -7,6 +7,7 @@ from rtslib_fb.alua import ALUATargetPortGroup
 
 import ceph_iscsi_config.settings as settings
 
+from ceph_iscsi_config.gateway_setting import TGT_SETTINGS
 from ceph_iscsi_config.utils import (normalize_ip_address, normalize_ip_literal,
                                      ip_addresses, this_host, format_lio_yes_no,
                                      CephiSCSIError, CephiSCSIInval)
@@ -24,20 +25,10 @@ class GWTarget(GWObject):
     """
     Class representing the state of the local LIO environment
     """
-    # iscsi tpg specific settings.
-    TPG_SETTINGS = [
-        "dataout_timeout",
-        "immediate_data",
-        "initial_r2t",
-        "max_outstanding_r2t",
-        "first_burst_length",
-        "max_burst_length",
-        "max_recv_data_segment_length",
-        "max_xmit_data_segment_length"]
 
     # Settings for all transport/fabric objects. Using this allows apps like
     # gwcli to get/set all tpgs/clients under the target instead of per obj.
-    SETTINGS = TPG_SETTINGS + GWClient.SETTINGS
+    SETTINGS = TGT_SETTINGS
 
     def __init__(self, logger, iqn, gateway_ip_list, enable_portal=True):
         """

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -13,7 +13,8 @@ from gwcli.node import UIGroup, UINode
 from gwcli.client import Clients
 
 from gwcli.utils import (console_message, response_message, GatewayAPIError,
-                         APIRequest, valid_snapshot_name, get_config)
+                         APIRequest, valid_snapshot_name, get_config,
+                         refresh_control_values)
 
 from ceph_iscsi_config.utils import valid_size, convert_2_bytes, human_size, this_host
 from ceph_iscsi_config.lun import LUN
@@ -688,13 +689,9 @@ class Disk(UINode):
         for k, v in image_config.items():
             disk_map[self.image_id][k] = v
             self.__setattr__(k, v)
-        for k in LUN.SETTINGS[image_config['backstore']]:
-            val = self.controls.get(k)
-            default_val = getattr(settings.config, k, None)
-            if val is None or str(val) == str(default_val):
-                self.control_values[k] = default_val
-            else:
-                self.control_values[k] = "{} (override)".format(val)
+
+        refresh_control_values(self.control_values, self.controls,
+                               LUN.SETTINGS[image_config['backstore']])
 
     def summary(self):
         if not self.exists:

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -10,8 +10,8 @@ from rtslib_fb.utils import normalize_wwn, RTSLibError
 
 from ceph_iscsi_config.client import GWClient
 import ceph_iscsi_config.settings as settings
-from ceph_iscsi_config.utils import (resolve_ip_addresses,
-                                     CephiSCSIError, this_host)
+from ceph_iscsi_config.utils import (resolve_ip_addresses, CephiSCSIError,
+                                     this_host)
 
 __author__ = 'Paul Cuzner'
 
@@ -383,6 +383,21 @@ def valid_snapshot_name(name):
     if not regex.search(name):
         return False
     return True
+
+
+def refresh_control_values(control_values, controls, def_settings):
+    for key, setting in def_settings.items():
+        val = controls.get(setting.name)
+        if val is not None:
+            # config values may be normalized or raw
+            val = setting.to_str(setting.normalize(val))
+
+        def_val = setting.to_str(getattr(settings.config, key))
+
+        if val is None or val == def_val:
+            control_values[setting.name] = def_val
+        else:
+            control_values[setting.name] = "{} (override)".format(val)
 
 
 class GatewayError(Exception):


### PR DESCRIPTION
The lio/ceph-iscsi settings values, limits, and definitions are spread all over. This moves it all to a new file and tries to remove a lot of the duplicated loops/checks/conversion/normalization code.