### PR TITLE
Add python requests

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -50,8 +50,10 @@ Requires:       python-flask >= 0.10.1
 Requires:       python-configshell >= 1.1.fb25
 %if 0%{?rhel} == 7
 Requires:       pyOpenSSL
+Requires:       python-requests
 %else
 Requires:       python-pyOpenSSL
+Requires:       python2-requests
 %endif
 %else
 BuildRequires:  python3-devel
@@ -62,6 +64,7 @@ Requires:       python3-netifaces >= 0.10.4
 Requires:       python3-rtslib >= 2.1.fb68
 Requires:       python3-cryptography
 Requires:       python3-pyOpenSSL
+Requires:       python3-requests
 %if 0%{?suse_version}
 BuildRequires:  python-rpm-macros
 BuildRequires:  fdupes


### PR DESCRIPTION
Fix

Sep 25 12:12:29 iscsi-gw0 rbd-target-api[9959]: import requests
Sep 25 12:12:29 iscsi-gw0 rbd-target-api[9959]: ImportError: No module named requests

python-requests used to be brought in my ceph-common, so we never
noticed we were missing out dep on it. This adds it to the spec