### PR TITLE
Allow explicit set LUN number and WWN

### DIFF
--- a/ceph_iscsi_config/group.py
+++ b/ceph_iscsi_config/group.py
@@ -119,14 +119,17 @@ class Group(object):
 
         return True
 
-    def _next_lun(self):
+    def _next_lun(self, preferred_lun_id):
         """
         Look at the disk list for the group and return the 1st available free
         LUN id used for adding disks to the group
         :return: (int) lun Id
         """
 
-        lun_range = list(range(0, 256, 1))      # 0->255
+        lun_range = list(range(0, 256, 1))  # 0->255
+        lun_range.remove(preferred_lun_id)
+        lun_range.insert(0, preferred_lun_id)
+
         target_config = self.config.config['targets'][self.target_iqn]
         group = target_config['groups'][self.group_name]
         group_disks = group.get('disks')
@@ -233,7 +236,7 @@ class Group(object):
         if disks.added:
             # update the groups disk list
             for disk in disks.added:
-                lun_seq = self._next_lun()
+                lun_seq = self._next_lun(target_config['disks'][disk]['lun_id'])
                 group_disks[disk] = {"lun_id": lun_seq}
                 self.logger.debug("- adding '{}' to group '{}' @ "
                                   "lun id {}".format(disk,

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -433,7 +433,7 @@ class LUN(GWObject):
             lun_id_candidate += 1
         return lun_id_candidate
 
-    def map_lun(self, gateway, owner, disk):
+    def map_lun(self, gateway, owner, disk, lun_id=None):
         target_config = self.config.config['targets'][gateway.iqn]
         disk_metadata = self.config.config['disks'][disk]
         disk_metadata['owner'] = owner
@@ -441,7 +441,8 @@ class LUN(GWObject):
 
         target_disk_config = target_config['disks'].get(disk)
         if not target_disk_config:
-            lun_id = self._get_next_lun_id(target_config['disks'])
+            if lun_id is None:
+                lun_id = self._get_next_lun_id(target_config['disks'])
             target_config['disks'][disk] = {
                 'lun_id': lun_id
             }

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -574,7 +574,7 @@ class LUN(GWObject):
             if client_err:
                 raise CephiSCSIError(client_err)
 
-    def allocate(self, keep_dev_in_lio=True):
+    def allocate(self, keep_dev_in_lio=True, in_wwn=None):
         """
         Create image and add to LIO and config.
 
@@ -685,10 +685,10 @@ class LUN(GWObject):
                 except KeyError:
                     wwn = ''
 
-                if wwn == '':
+                if wwn == '' or in_wwn is not None:
                     # disk hasn't been defined to LIO yet, it' not been defined
                     # to the config yet and this is the allocating host
-                    so = self.add_dev_to_lio()
+                    so = self.add_dev_to_lio(in_wwn)
                     if self.error:
                         return None
 
@@ -1013,9 +1013,16 @@ class LUN(GWObject):
             if not disk_regex.search(kwargs['image']):
                 return "Invalid image name (use alphanumeric, '_', '.', or '-' characters)"
 
+            if kwargs['wwn'] is not None:
+                for disk_id, disk_config in config['disks'].items():
+                    if disk_config['wwn'] == kwargs['wwn']:
+                        return "WWN {} is already in use by {}".format(kwargs['wwn'], disk_id)
+
             if kwargs['count'].isdigit():
                 if not 1 <= int(kwargs['count']) <= 10:
                     return "invalid count specified, must be an integer (1-10)"
+                if int(kwargs['count']) > 1 and kwargs['wwn'] is not None:
+                    return "WWN cannot be specified when count > 1"
             else:
                 return "invalid count specified, must be an integer (1-10)"
 

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -562,7 +562,7 @@ class Client(UINode):
         mapped_disks = [mapped_disk.name
                         for mapped_disk in self.parent.parent.target_disks.children]
         if disk not in mapped_disks:
-            rc = self.parent.parent.target_disks.add_disk(disk, None)
+            rc = self.parent.parent.target_disks.add_disk(disk, None, None)
             if rc == 0:
                 self.logger.debug("disk auto-map successful")
             else:

--- a/gwcli/hostgroup.py
+++ b/gwcli/hostgroup.py
@@ -325,7 +325,7 @@ class HostGroup(UIGroup):
         mapped_disks = [mapped_disk.name
                         for mapped_disk in self.parent.parent.target_disks.children]
         if disk_name not in mapped_disks:
-            rc = self.parent.parent.target_disks.add_disk(disk_name, None)
+            rc = self.parent.parent.target_disks.add_disk(disk_name, None, None)
             if rc == 0:
                 self.logger.debug("disk auto-map successful")
             else:

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -153,7 +153,7 @@ class Disks(UIGroup):
         for child in children:
             self.remove_child(child)
 
-    def ui_command_attach(self, pool=None, image=None, backstore=None):
+    def ui_command_attach(self, pool=None, image=None, backstore=None, wwn=None):
         """
         Assign a previously created RBD image to the gateway(s)
 
@@ -187,9 +187,10 @@ class Disks(UIGroup):
 
         self.logger.debug("CMD: /disks/ attach pool={} "
                           "image={}".format(pool, image))
-        self.create_disk(pool=pool, image=image, create_image=False, backstore=backstore)
+        self.create_disk(pool=pool, image=image, create_image=False, backstore=backstore, wwn=wwn)
 
-    def ui_command_create(self, pool=None, image=None, size=None, backstore=None, count=1):
+    def ui_command_create(self, pool=None, image=None, size=None, backstore=None, wwn=None,
+                          count=1):
         """
         Create a RBD image and assign to the gateway(s).
 
@@ -208,6 +209,7 @@ class Disks(UIGroup):
         size  : integer, suffixed by the allocation unit - either m/M, g/G or
                 t/T representing the MB/GB/TB [1]
         backstore  : lio backstore
+        wwn   : unit serial number
         count : integer (default is 1)[2]. If the request provides a count=<n>
                 parameter the image name will be used as a prefix, and the count
                 used as a suffix to create multiple images from the same request.
@@ -258,7 +260,8 @@ class Disks(UIGroup):
         self.logger.debug("CMD: /disks/ create pool={} "
                           "image={} size={} "
                           "count={} ".format(pool, image, size, count))
-        self.create_disk(pool=pool, image=image, size=size, count=count, backstore=backstore)
+        self.create_disk(pool=pool, image=image, size=size, count=count, backstore=backstore,
+                         wwn=wwn)
 
     def _valid_pool(self, pool=None):
         """
@@ -283,7 +286,7 @@ class Disks(UIGroup):
         return False
 
     def create_disk(self, pool=None, image=None, size=None, count=1,
-                    parent=None, create_image=True, backstore=None):
+                    parent=None, create_image=True, backstore=None, wwn=None):
 
         rc = 0
 
@@ -307,7 +310,7 @@ class Disks(UIGroup):
         api_vars = {'pool': pool, 'owner': local_gw,
                     'count': count, 'mode': 'create',
                     'create_image': 'true' if create_image else 'false',
-                    'backstore': backstore}
+                    'backstore': backstore, 'wwn': wwn}
         if size:
             api_vars['size'] = size.upper()
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2498,7 +2498,8 @@ def get_settings():
         'default_backstore': LUN.DEFAULT_BACKSTORE,
         'config': {
             'minimum_gateways': settings.config.minimum_gateways
-        }
+        },
+        'api_version': 1
     }), 200
 
 


### PR DESCRIPTION
This PR will allow the user to optionally specify the **LUN number** and **WWN**.

Note that if not explicitly set, then the LUN number and WWN will be automatically generated.

With this change `"ceph-iscsi" + "Ceph Dashboard"` will reach feature parity with `"lrbd" + "openATTIC"`. 

Just for reference, here is a print screen from the openATTIC:
![Screenshot from 2019-10-17 09-25-52](https://user-images.githubusercontent.com/14297426/67022439-259bc800-f0f9-11e9-8cf7-a76923e6e1f2.png)

Also, this PR adds a new `api_version` field to the settings endpoint response so consumers of the API can have more control on how to consume the API.

This `api_version` should be incremented every time the API changes. 
