### PR TITLE
Fix group disk add on python3

### DIFF
--- a/ceph_iscsi_config/group.py
+++ b/ceph_iscsi_config/group.py
@@ -169,7 +169,7 @@ class Group(object):
 
         members = ListComparison(this_group.get('members'),
                                  self.group_members)
-        disks = ListComparison(this_group.get('disks').keys(),
+        disks = ListComparison(list(this_group.get('disks').keys()),
                                self.disks)
 
         if set(self.disks) != set(this_group.get('disks')) or \


### PR DESCRIPTION
In a **python3** environment, I have the following configuration:

```
/iscsi-target...t-groups/myg1> ls ../..
o- iqn.2001-07.com.ceph:1571910286153 .................................................................... [Auth: None, Gateways: 2]
  o- disks .............................................................................................................. [Disks: 3]
  | o- rbd/img1 .......................................................................................... [Owner: node1.ceph.local]
  | o- rbd/img2 .......................................................................................... [Owner: node2.ceph.local]
  | o- rbd/img3 .......................................................................................... [Owner: node1.ceph.local]
  o- gateways ................................................................................................ [Up: 2/2, Portals: 2]
  | o- node1.ceph.local ..................................................................................... [192.168.100.201 (UP)]
  | o- node2.ceph.local ..................................................................................... [192.168.100.202 (UP)]
  o- host-groups ...................................................................................................... [Groups : 1]
  | o- myg1 ................................................................................................... [Hosts: 1, Disks: 2]
  |   o- iqn.2001-07.com.ceph:1571910286153-c1 .............................................................................. [host]
  |   o- rbd/img1 ........................................................................................................... [disk]
  |   o- rbd/img2 ........................................................................................................... [disk]
  o- hosts ........................................................................................... [Auth: ACL_ENABLED, Hosts: 1]
    o- iqn.2001-07.com.ceph:1571910286153-c1 ........................................................... [Auth: None, Disks: 2(91G)]
      o- lun 0 ............................................................................. [rbd/img1(1G), Owner: node1.ceph.local]
      o- lun 1 ............................................................................ [rbd/img2(90G), Owner: node2.ceph.local]
```

When I add a disk to the group, that disk is not added to the client:

```
/iscsi-target...t-groups/myg1> disk add rbd/img3
ok
/iscsi-target...t-groups/myg1> ls ../..
o- iqn.2001-07.com.ceph:1571910286153 .................................................................... [Auth: None, Gateways: 2]
  o- disks .............................................................................................................. [Disks: 3]
  | o- rbd/img1 .......................................................................................... [Owner: node1.ceph.local]
  | o- rbd/img2 .......................................................................................... [Owner: node2.ceph.local]
  | o- rbd/img3 .......................................................................................... [Owner: node1.ceph.local]
  o- gateways ................................................................................................ [Up: 2/2, Portals: 2]
  | o- node1.ceph.local ..................................................................................... [192.168.100.201 (UP)]
  | o- node2.ceph.local ..................................................................................... [192.168.100.202 (UP)]
  o- host-groups ...................................................................................................... [Groups : 1]
  | o- myg1 ................................................................................................... [Hosts: 1, Disks: 3]
  |   o- iqn.2001-07.com.ceph:1571910286153-c1 .............................................................................. [host]
  |   o- rbd/img1 ........................................................................................................... [disk]
  |   o- rbd/img2 ........................................................................................................... [disk]
  |   o- rbd/img3 ........................................................................................................... [disk]
  o- hosts ........................................................................................... [Auth: ACL_ENABLED, Hosts: 1]
    o- iqn.2001-07.com.ceph:1571910286153-c1 ........................................................... [Auth: None, Disks: 2(91G)]
      o- lun 0 ............................................................................. [rbd/img1(1G), Owner: node1.ceph.local]
      o- lun 1 ............................................................................ [rbd/img2(90G), Owner: node2.ceph.local]
```

This happens because, before line https://github.com/ceph/ceph-iscsi/blob/master/ceph_iscsi_config/group.py#L237, `disks.added` is `['rbd/img3']`, but after that line `disks.added` is `[]`.

Here is a small **python3** script that reproduces the problems:

```
group_disks = {'rbd/img1': {'lun_id': 0}, 'rbd/img2': {'lun_id': 1}}
disks = ListComparison(group_disks.keys(), ['rbd/img1', 'rbd/img2', 'rbd/img3'])
print ('disks.added = {}'.format(disks.added))
group_disks[disks.added[0]] = {"lun_id": 3}
print ('disks.added = {}'.format(disks.added))
```
will print:
```
disks.added = ['rbd/img3']
disks.added = []
```

but if we apply the fix to script:

```
group_disks = {'rbd/img1': {'lun_id': 0}, 'rbd/img2': {'lun_id': 1}}
disks = ListComparison(list(group_disks.keys()), ['rbd/img1', 'rbd/img2', 'rbd/img3'])
print ('disks.added = {}'.format(disks.added))
group_disks[disks.added[0]] = {"lun_id": 3}
print ('disks.added = {}'.format(disks.added))
```
then it will print the expected result:
```
disks.added = ['rbd/img3']
disks.added = ['rbd/img3']
```




Signed-off-by: Ricardo Marques <rimarques@suse.com>