### PR TITLE
Fix ZeroDivisionError

### DIFF
--- a/gwcli/ceph.py
+++ b/gwcli/ceph.py
@@ -298,8 +298,11 @@ class RadosPool(UINode):
                     potential_demand += image_child.size
 
         self.commit = potential_demand
-        self.overcommit_PCT = int(
-            (potential_demand / float(self.max_bytes)) * 100)
+        if self.max_bytes == 0:
+            self.overcommit_PCT = 0
+        else:
+            self.overcommit_PCT = int(
+                (potential_demand / float(self.max_bytes)) * 100)
 
     def update(self, pool_metadata):
 


### PR DESCRIPTION
 excute command  gwcli,the output as follow 
Gathering pool stats for cluster 'ceph'
Traceback (most recent call last):
  File "/usr/bin/gwcli", line 194, in <module>
    main()
  File "/usr/bin/gwcli", line 105, in main
    root_node.refresh()
  File "/usr/lib/python2.7/site-packages/ceph_iscsi-3.0-py2.7.egg/gwcli/gateway.py", line 76, in refresh
  File "/usr/lib/python2.7/site-packages/ceph_iscsi-3.0-py2.7.egg/gwcli/ceph.py", line 61, in refresh
  File "/usr/lib/python2.7/site-packages/ceph_iscsi-3.0-py2.7.egg/gwcli/ceph.py", line 272, in refresh
  File "/usr/lib/python2.7/site-packages/ceph_iscsi-3.0-py2.7.egg/gwcli/ceph.py", line 309, in update
  File "/usr/lib/python2.7/site-packages/ceph_iscsi-3.0-py2.7.egg/gwcli/ceph.py", line 302, in _calc_overcommit
ZeroDivisionError: float division by zero


cluster info ceph df 
POOLS:
    NAME                    ID     USED        %USED     MAX AVAIL     OBJECTS
    test-pool               26         0 B         0           0 B           0 

if the cluster has pool that MAX AVAIL is 0,the command gwcli can not be excute.