### PR TITLE
Add option to force deletion of unreachable gw

### DIFF
--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -18,10 +18,13 @@ __author__ = 'pcuzner@redhat.com'
 
 class CephiSCSIGateway(object):
 
-    def __init__(self, logger, config):
+    def __init__(self, logger, config, name=None):
         self.logger = logger
         self.config = config
-        self.hostname = this_host()
+        if name:
+            self.hostname = name
+        else:
+            self.hostname = this_host()
 
     def ceph_rm_blacklist(self, blacklisted_ip):
         """

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -749,8 +749,10 @@ class GatewayGroup(UIGroup):
         self.logger.debug("{}".format(msg))
         self.logger.debug("Removing gw from UI")
 
+        self.thread_lock.acquire()
         gw_object = self.get_child(gateway_name)
         self.remove_child(gw_object)
+        self.thread_lock.release()
 
         config = self.parent.parent.parent._get_config()
         if not config:

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -756,7 +756,7 @@ class GatewayGroup(UIGroup):
 
         config = self.parent.parent.parent._get_config()
         if not config:
-            self.logger.error("Could not refresh disaply. Restart gwcli.")
+            self.logger.error("Could not refresh display. Restart gwcli.")
         elif not config['targets'][target_iqn]['portals']:
             # no more gws so everything but the target is dropped.
             disks_object = self.parent.get_child("disks")

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -580,6 +580,7 @@ def gateway(target_iqn=None, gateway_name=None):
            default: FALSE
     :param skipchecks: (bool) whether to skip OS/software versions checks
            default: FALSE
+    :param force: (bool) if True will force removal of gateway.
     **RESTRICTED**
     Examples:
     curl --insecure --user admin:admin -d ip_address=192.168.122.69
@@ -657,10 +658,21 @@ def gateway(target_iqn=None, gateway_name=None):
     if first_gateway:
         gateways = ['localhost']
     elif request.method == 'DELETE':
-        # Update the deleted gw first, so the other gws see the updated
-        # portal list
         gateways.remove(gateway_name)
-        gateways.insert(0, gateway_name)
+
+        if request.form.get('force', 'false').lower() == 'true':
+            # The gw we want to delete is down and the user has decided to
+            # force the deletion, so we do the config modification locally
+            # then only tell the other gws to update their state.
+            try:
+                ceph_gw = CephiSCSIGateway(logger, config, gateway_name)
+                ceph_gw.remove_from_config(target_iqn)
+            except CephiSCSIError as err:
+                return jsonify(message="Could not update config: {}.".format(err)), 400
+        else:
+            # Update the deleted gw first, so the other gws see the updated
+            # portal list
+            gateways.insert(0, gateway_name)
     else:
         # Update the new gw first, so other gws see the updated gateways list.
         gateways.insert(0, gateway_name)


### PR DESCRIPTION
The first patch fixes the issue where if a gw is dead, we can't delete it because we normally update the config on the node we are updating. The other patches fix some bugs/issues found while testing it.