### PR TITLE
Modify the configuration file name

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -75,7 +75,7 @@ class Config(object):
 
     lock_time_limit = 30
 
-    def __init__(self, logger, cfg_name='gateway.conf', pool=None):
+    def __init__(self, logger, cfg_name='iscsi-gateway.cfg', pool=None):
         self.logger = logger
         self.config_name = cfg_name
         if pool is None:


### PR DESCRIPTION
The ceph documentation indicates that the name of the configuration file created on the iSCSI gateway node is iscsi-gateway.cfg, but the name in the code is gateway.conf, which will cause the service to fail to start properly.