### PR TITLE
Fix ceph blacklist ls test

### DIFF
--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -98,9 +98,14 @@ class CephiSCSIGateway(object):
                     dev_info = netifaces.ifaddresses(iface).get(netifaces.AF_INET, [])
                     ipv4_list += [dev['addr'] for dev in dev_info]
 
-                # process the entries (first entry just says "Listed X entries,
-                # last entry is just null)
-                for blacklist_entry in blacklist_output[1:]:
+                # process the entries. last entry is just null)
+                for blacklist_entry in blacklist_output:
+
+                    # blacklist_output is not gauranteed to be in order returned
+                    # from the ceph command. 'listed N entries' line could be
+                    # at any index.
+                    if "listed" in blacklist_entry:
+                        continue
 
                     # valid entries to process look like -
                     # 192.168.122.101:0/3258528596 2016-09-28 18:23:15.307227


### PR DESCRIPTION
I am not sure if it could always happen or it is a change in python3,
but while testing the blacklist clean up code with python3 we
sometimes do not see the blacklist get fully cleaned up. The problem
is that sometimes blacklist.decode() will change the order of the
returned items so the "list N entries" string. When we look over the
output we then skip the first one and it does not get cleaned up.