### PR TITLE
iscsi: Attempt to pull SSL crt and key's from mon config-key store

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -10,6 +10,7 @@ from logging.handlers import RotatingFileHandler
 import ssl
 import operator
 import OpenSSL
+import tempfile
 import threading
 import time
 import inspect
@@ -2816,13 +2817,48 @@ class ConfigWatcher(threading.Thread):
                     config.refresh()
 
 
+def get_ssl_files_from_mon():
+    client_name = settings.config.cluster_client_name
+    temp_files = []
+    with rados.Rados(conffile=settings.config.cephconf,
+                     name=client_name) as cluster:
+        cmd = {"prefix": "config-key get",
+               "key": "iscsi/{}/iscsi-gateway.crt".format(client_name)}
+        ret, crt_data, outs = cluster.mon_command(json.dumps(cmd), b'')
+        if ret:
+            return temp_files
+
+        cmd["key"] = "iscsi/{}/iscsi-gateway.key".format(client_name)
+        ret, key_data, outs = cluster.mon_command(json.dumps(cmd), b'')
+        if ret:
+            return temp_files
+    for data in crt_data, key_data:
+        # NOTE: Annoyingly SSLContext.load_cert_chain can only take
+        # paths to files and not file like objects.. yet. So we need to
+        # create tempfiles for the SSL context to read. Once
+        # https://bugs.python.org/issue16487 is resolved, we should be able
+        # to simply use file-like objects and makes this much nicer.
+
+        tmp_f = tempfile.NamedTemporaryFile()
+        tmp_f.write(data)
+        tmp_f.flush()
+        temp_files.append(tmp_f)
+    return temp_files
+
+
 def get_ssl_context():
     # Use these self-signed crt and key files
     cert_files = ['/etc/ceph/iscsi-gateway.crt',
                   '/etc/ceph/iscsi-gateway.key']
+    temp_files = []
 
     if not all([os.path.exists(crt_file) for crt_file in cert_files]):
-        return None
+        # attempt to pull out the crt and key data from global mon config-key
+        # storage, we need to return the tempfiles so they're not gc'ed.
+        temp_files = get_ssl_files_from_mon()
+        cert_files = [f.name for f in temp_files]
+        if not cert_files or not all([os.path.exists(crt_file) for crt_file in cert_files]):
+            return None
 
     ver, rel, mod = werkzeug.__version__.split('.')
     if int(rel) > 9:
@@ -2843,6 +2879,10 @@ def get_ssl_context():
             logger.critical("SSL Error : {}".format(err))
             return None
 
+    # If we have loaded the certs into tempfiles we can clean them up now.
+    # This should happen when we return, but let's be explicit.
+    for f in temp_files:
+        f.close()
     return context
 
 


### PR DESCRIPTION
I'm looking at attempting to add iscsi to cephadm, but frankly having
to place the crt and key inside the container makes things a little
harder. While working on adding RGW SSL support to cephadm sage et al,
suggested we should use the mon config-key store the certs[0][1].

So thought why not fo the same here. This will mean when setting up
service in cephadm, an op can either place the certs:

  ceph config-key put 'iscsi/<client-name>/iscsi-gateway.crt -i <file>
  ceph config-key put 'iscsi/<client-name>/iscsi-gateway.key -i <file>

Or if given the files via cephadm we can place them on their behalf.

[0]- https://github.com/ceph/ceph/pull/32951
[1]- https://github.com/ceph/ceph/pull/33287

Signed-off-by: Matthew Oliver <moliver@suse.com>