### PR TITLE
ubuntu: drop minimum version requirement to 18.04

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2737,7 +2737,7 @@ def pre_reqs_errors():
         "rhel": 7.4,
         "suse": 15.1,
         "debian": 10,
-        "ubuntu": 19.04}
+        "ubuntu": 18.04}
 
     errors_found = []
 


### PR DESCRIPTION
Ubuntu 18.04 supplies later Linux kernels as part of hardware
enablement, with kernels up to and including 5.3 being avaliable
for use.

Drop minimum Ubuntu version from 19.04->18.04 to support use
on the most recent Ubuntu LTS version.

Signed-off-by: James Page <james.page@ubuntu.com>