### PR TITLE
Fix resolve_ip_addresses formatting

### DIFF
--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -86,7 +86,11 @@ def resolve_ip_addresses(addr):
         infos = socket.getaddrinfo(addr, 0)
         for info in infos:
             if info[0] in families:
-                addrs.add(info[4][0])
+                # remove interface scope suffix and IPv4-over-IPv6 prefix
+                addr = info[4][0]
+                addr = addr.rsplit('%', 1)[0]
+                addr = addr.split('::ffff:', 1)[-1]
+                addrs.add(addr)
     except Exception:
         pass
 


### PR DESCRIPTION
This has resolve_ip_addresses return addresses in the format expected by
the caller. Specifically, requires_restricted_auth expects that the
interface scope and leading "::ffff:" are dropped.

Note:
I am not 100% sure when we even see this. We have had a couple users hit the issue though. One known case is when the user mis-sets the IP in the /etc/hosts file. In this case if you just added an extra dot:

192.168.1..100 somehost.local

then getaddrinfo will return both the link local ipv6 addr and a corrected ipv4 addr. If the address is correct though, then we get the ipv4 address only.

In other cases, we have not seen any misconfigs, so I am guessing it might be differences in python versions, or expected behavior in certain configs. However, I am not sure what those are right now.