### PR TITLE
Allow target reconfigure without clients

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -277,10 +277,6 @@ def target(target_iqn=None):
                 return jsonify(message="Target: {} is not defined."
                                        "".format(target_iqn)), 400
 
-            if client_controls and not target_config['clients']:
-                return jsonify(message="No clients found. Create clients then "
-                                       "rerun reconfigure command."), 400
-
         gateway_ip_list = []
         target = GWTarget(logger,
                           str(target_iqn),
@@ -2511,7 +2507,7 @@ def get_settings():
         'config': {
             'minimum_gateways': settings.config.minimum_gateways
         },
-        'api_version': 1
+        'api_version': 2
     }), 200
 
 


### PR DESCRIPTION
To fix a Dashboard issue **[1]**, we need to be able to set target controls even if we don't have any client configured yet.

I've noticed that this check was introduced to guarantee that we only accept valid values(https://github.com/ceph/ceph-iscsi/pull/44/commits/f44d18418329d1982031e8baceeeeddf8d0fc715), but since we are now validating control values beforehand **[2]** I think it's safe to drop this check.

We are also bumping the API version so Dashboard can be backward compatible.

**[1]** https://tracker.ceph.com/issues/44659
**[2]** https://github.com/ceph/ceph-iscsi/blob/master/ceph_iscsi_config/gateway_setting.py#L146

Signed-off-by: Ricardo Marques <rimarques@suse.com>