### PR TITLE
fix scan rbd image stuck

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -663,6 +663,8 @@ class GWClient(GWObject):
 
                         # persist the config update
                         config_object.commit()
+                        if config_object.error:
+                            self.error = True
 
         elif rqst_type == 'reconfigure':
             self.define_client()
@@ -685,6 +687,8 @@ class GWClient(GWObject):
                         target_config['clients'].pop(self.iqn)
                         config_object.update_item("targets", self.target_iqn, target_config)
                         config_object.commit()
+                        if config_object.error:
+                            self.error = True
 
             else:
                 # desired state is absent, but the client does not exist

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -76,7 +76,7 @@ class Disks(UIGroup):
                 disk_meta[rbd_name] = {}
                 with cluster_ioctx.open_ioctx(pool) as ioctx:
                     try:
-                        with rbd.Image(ioctx, image) as rbd_image:
+                        with rbd.Image(ioctx, image, read_only=True) as rbd_image:
                             size = rbd_image.size()
                             features = rbd_image.features()
                             snapshots = list(rbd_image.list_snaps())


### PR DESCRIPTION
1. client.py :
    config submission may fail, there should be a return value judgment.
2. storage.py ：
    when the rbd image is full, it cannot operate because of the write lock. 
    “with rbd.Image (ioctx, image) as rbd_image:” stuck, 
    it can be adjusted to read-only mode to read image information.
   