### PR TITLE
Fix scan rbd image stuck

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -665,6 +665,7 @@ class GWClient(GWObject):
                         config_object.commit()
                         if config_object.error:
                             self.error = True
+                            self.error_msg = config_object.error_msg
 
         elif rqst_type == 'reconfigure':
             self.define_client()
@@ -689,6 +690,7 @@ class GWClient(GWObject):
                         config_object.commit()
                         if config_object.error:
                             self.error = True
+                            self.error_msg = config_object.error_msg
 
             else:
                 # desired state is absent, but the client does not exist

--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -663,6 +663,8 @@ class GWClient(GWObject):
 
                         # persist the config update
                         config_object.commit()
+                        if config_object.error:
+                            self.error = True
 
         elif rqst_type == 'reconfigure':
             self.define_client()
@@ -685,6 +687,8 @@ class GWClient(GWObject):
                         target_config['clients'].pop(self.iqn)
                         config_object.update_item("targets", self.target_iqn, target_config)
                         config_object.commit()
+                        if config_object.error:
+                            self.error = True
 
             else:
                 # desired state is absent, but the client does not exist

--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -482,13 +482,12 @@ class Config(object):
 
     def _seed_rbd_config(self):
 
-        ioctx = self._open_ioctx()
-
         self.lock()
         if self.error:
             return
 
         # if the config object is empty, seed it - if not just leave as is
+        ioctx = self._open_ioctx()
         cfg_data = self._read_config_object(ioctx)
         if not cfg_data:
             self.logger.debug("_seed_rbd_config found empty config object")
@@ -499,6 +498,7 @@ class Config(object):
             ioctx.set_xattr(self.config_name, "epoch", "0".encode('utf-8'))
             self.changed = True
 
+        ioctx.close()
         self.unlock()
 
     def refresh(self):
@@ -591,8 +591,6 @@ class Config(object):
 
     def _commit_rbd(self, post_action):
 
-        ioctx = self._open_ioctx()
-
         if not self.config_locked:
             self.lock()
             if self.error:
@@ -600,6 +598,7 @@ class Config(object):
 
         # reread the config to account for updates made by other systems
         # then apply this hosts update(s)
+        ioctx = self._open_ioctx()
         current_config = json.loads(self._read_config_object(ioctx))
         for txn in self.txn_list:
 
@@ -638,8 +637,8 @@ class Config(object):
                             str(current_config["epoch"]).encode('utf-8'))
             del self.txn_list[:]                # empty the list of transactions
 
-        self.unlock()
         ioctx.close()
+        self.unlock()
 
         if post_action == 'close':
             self.ceph.shutdown()

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -167,7 +167,7 @@ class RBDDev(object):
         with rados.Rados(conffile=settings.config.cephconf,
                          name=settings.config.cluster_client_name) as cluster:
             with cluster.open_ioctx(self.pool) as ioctx:
-                with rbd.Image(ioctx, self.image) as rbd_image:
+                with rbd.Image(ioctx, self.image, read_only=True) as rbd_image:
                     image_size = rbd_image.size()
 
         return image_size
@@ -223,8 +223,7 @@ class RBDDev(object):
         with rados.Rados(conffile=settings.config.cephconf,
                          name=settings.config.cluster_client_name) as cluster:
             ioctx = cluster.open_ioctx(self.pool)
-            with rbd.Image(ioctx, self.image) as rbd_image:
-
+            with rbd.Image(ioctx, self.image, read_only=True) as rbd_image:
                 if rbd_image.features() & RBDDev.required_features(self.backstore) != \
                         RBDDev.required_features(self.backstore):
                     valid_state = False
@@ -367,6 +366,8 @@ class LUN(GWObject):
             self.config.del_item('disks', self.config_key)
 
             self.config.commit()
+            self.error = self.config.error
+            self.error_msg = self.config.error_msg
 
     def unmap_lun(self, target_iqn):
         local_gw = this_host()
@@ -425,6 +426,8 @@ class LUN(GWObject):
             self.config.update_item("disks", self.config_key, disk_metadata)
 
             self.config.commit()
+            self.error = self.config.error
+            self.error_msg = self.config.error_msg
 
     def _get_next_lun_id(self, target_disks):
         lun_ids_in_use = [t['lun_id'] for t in target_disks.values()]

--- a/ceph_iscsi_config/target.py
+++ b/ceph_iscsi_config/target.py
@@ -652,6 +652,9 @@ class GWTarget(GWObject):
 
             if self.config_updated:
                 config.commit()
+                if config.error:
+                    self.error = True
+                    self.error_msg = config.error_msg
 
         elif mode == 'map':
 
@@ -698,6 +701,9 @@ class GWTarget(GWObject):
                 }
                 config.add_item("targets", self.iqn, seed_target)
                 config.commit()
+                if config.error:
+                    self.error = True
+                    self.error_msg = config.error_msg
 
                 discovery_auth_config = config.config['discovery_auth']
                 Discovery.set_discovery_auth_lio(discovery_auth_config['username'],
@@ -744,6 +750,9 @@ class GWTarget(GWObject):
                     config.del_item('gateways', local_gw)
 
             config.commit()
+            if config.error:
+                self.error = True
+                self.error_msg = config.error_msg
 
     @staticmethod
     def get_num_sessions(target_iqn):

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -250,7 +250,7 @@ def get_rbd_size(pool, image, conf=None):
 
     with rados.Rados(conffile=conf, name=settings.config.cluster_client_name) as cluster:
         with cluster.open_ioctx(pool) as ioctx:
-            with rbd.Image(ioctx, image) as rbd_image:
+            with rbd.Image(ioctx, image, read_only=True) as rbd_image:
                 size = rbd_image.size()
     return size
 

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -752,7 +752,7 @@ class Disk(UINode):
                          name=settings.config.cluster_client_name) as cluster:
             with cluster.open_ioctx(self.pool) as ioctx:
                 try:
-                    with rbd.Image(ioctx, self.image) as rbd_image:
+                    with rbd.Image(ioctx, self.image, read_only=True) as rbd_image:
                         self.exists = True
                         self.size = rbd_image.size()
                         self.size_h = human_size(self.size)

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -76,7 +76,7 @@ class Disks(UIGroup):
                 disk_meta[rbd_name] = {}
                 with cluster_ioctx.open_ioctx(pool) as ioctx:
                     try:
-                        with rbd.Image(ioctx, image) as rbd_image:
+                        with rbd.Image(ioctx, image, read_only=True) as rbd_image:
                             size = rbd_image.size()
                             features = rbd_image.features()
                             snapshots = list(rbd_image.list_snaps())


### PR DESCRIPTION
client.py :
config submission may fail, there should be a return value judgment.

storage.py ：
when the rbd image is full, it cannot operate because of the write lock.
“with rbd.Image (ioctx, image) as rbd_image:” stuck,
it can be adjusted to read-only mode to read image information.
