### PR TITLE
Add a config option to log to stderr

### DIFF
--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -190,6 +190,9 @@ SYS_SETTINGS = {
     "prometheus_host": StrSetting("prometheus_host", "::"),
     "logger_level": IntSetting("logger_level", logging.DEBUG, logging.CRITICAL,
                                logging.DEBUG),
+    "log_to_stderr": BoolSetting("log_to_stderr", False),
+    "log_to_stderr_prefix": StrSetting("log_to_stderr_prefix", ""),
+    "log_to_file": BoolSetting("log_to_file", True),
     # TODO: This is under sys for compat. It is not settable per device/backend
     # type yet.
     "alua_failover_type": EnumSetting("alua_failover_type",


### PR DESCRIPTION
Most the other ceph components have an option to get them to log to
stderr. And this is used when containerising to help gather logs.

This patch adds a config options `log_to_stderr`, `log_to_stderr_prefix`
and `log_to_file` to do the same for ceph-iscsi. These are matching the
other ceph daemon's:

  --default-log-to-stderr=true --default-log-stderr-prefix="debug "
  --default-log-to-file=false

Signed-off-by: Matthew Oliver <moliver@suse.com>