### PR TITLE
Report tcmu-runner device status

### DIFF
--- a/ceph_iscsi_config/device_status.py
+++ b/ceph_iscsi_config/device_status.py
@@ -1,0 +1,155 @@
+import json
+import rados
+import threading
+import time
+
+import ceph_iscsi_config.settings as settings
+
+
+class StatusCounter(object):
+    def __init__(self, name, cnt):
+        self.name = name
+        self.cnt = cnt
+        self.last_cnt = cnt
+
+
+class TcmuDevStatusTracker(object):
+    def __init__(self, image_name):
+        self.image_name = image_name
+        self.gw_counter_lookup = {}
+        self.lock_owner = ""
+        self.state = "Online"
+        self.changed_state = False
+        self.stable_cnt = 0
+
+    def get_status_dict(self):
+        status = {}
+
+        status['state'] = self.state
+        status['lock_owner'] = self.lock_owner
+        status['gateways'] = {}
+
+        for gw, stat_cnt_dict in self.gw_counter_lookup.items():
+            status['gateways'][gw] = {}
+
+            for name, stat_cnt in stat_cnt_dict.items():
+                status['gateways'][gw][name] = stat_cnt.cnt
+
+        return status
+
+    def check_for_degraded_state(self, stat_cnt):
+        if stat_cnt.name == "cmd_timed_out_cnt" or \
+           stat_cnt.name == "conn_lost_cnt":
+            if abs(stat_cnt.cnt - stat_cnt.last_cnt) >= 1:
+                self.state = "Degraded - cluster access failure"
+                self.changed_state = True
+                self.stable_cnt = 0
+                return
+
+        if stat_cnt.name == "lock_lost_cnt" and \
+           abs(stat_cnt.cnt - stat_cnt.last_cnt) >= \
+           settings.config.lock_lost_cnt_thresh:
+            self.state = "Degraded - excessive failovers"
+            self.changed_state = True
+            self.stable_cnt = 0
+            return
+
+    def update_status(self, gw, status):
+        if status is None:
+            # Sometimes status calls will return empty statuses even though
+            # there is valid data. We might not see it until the Nth call.
+            return
+
+        counter_dict = self.gw_counter_lookup.get(gw)
+        if counter_dict is None:
+            counter_dict = {}
+
+        for name, val in status.items():
+            if name == "lock_owner" and val == "true":
+                self.lock_owner = gw
+                continue
+
+            if name != "cmd_timed_out_cnt" and name != "conn_lost_cnt" and \
+               name != "lock_lost_cnt":
+                continue
+
+            stat_cnt = counter_dict.get(name)
+            if stat_cnt is None:
+                stat_cnt = StatusCounter(name, int(val))
+
+            stat_cnt.cnt = int(val)
+            # TODO:
+            # If we detect a degraded state, we can throttle the path here.
+            self.check_for_degraded_state(stat_cnt)
+            stat_cnt.last_cnt = stat_cnt.cnt
+
+            counter_dict[name] = stat_cnt
+
+        self.gw_counter_lookup[gw] = counter_dict
+
+
+class DeviceStatusWatcher(threading.Thread):
+    def __init__(self, logger):
+        threading.Thread.__init__(self)
+        self.logger = logger
+        self.daemon = True
+        self.cluster = None
+        self.status_lookup = {}
+
+    def get_dev_status(self, image_name):
+        return self.status_lookup.get(image_name)
+
+    def exit(self):
+        if self.cluster:
+            self.cluster.shutdown()
+
+    def run(self):
+        self.cluster = rados.Rados(conffile=settings.config.cephconf,
+                                   name=settings.config.cluster_client_name)
+        self.cluster.connect()
+
+        while True:
+            time.sleep(settings.config.status_check_interval)
+
+            cmd = json.dumps({"prefix": "service status", "format": "json"})
+
+            ret, outb, outs = self.cluster.mon_command(cmd, b'')
+            if ret != 0:
+                self.logger.error("mon command failed {}".format(ret))
+                continue
+
+            svc = json.loads(outb).get('tcmu-runner')
+            if svc is None:
+                continue
+
+            image_names_dict = {}
+            for daemon, daemon_info in svc.items():
+                gw, image_name = daemon.split(":", 1)
+                image_names_dict[image_name] = image_name
+
+                dev_status = self.get_dev_status(image_name)
+                if dev_status is None:
+                    dev_status = TcmuDevStatusTracker(image_name)
+                    self.status_lookup[image_name] = dev_status
+
+                dev_status.update_status(gw, daemon_info.get('status'))
+
+            # cleanup stale entries and try to move to online if a dev
+            # didn't not see any errors on every gateway for a while
+            for image_name, dev_status in self.status_lookup.items():
+                if image_names_dict.get(image_name) is None:
+                    del self.status_lookup[image_name]
+                else:
+                    if dev_status.changed_state is False:
+                        dev_status.stable_cnt += 1
+
+                        if dev_status.stable_cnt > settings.config.stable_state_reset_cnt:
+                            dev_status.stable_cnt = 0
+                            dev_status.state = "Online"
+                    else:
+                        dev_status.changed_state = False
+
+            # debugging info
+            dev_status = self.get_dev_status(image_name)
+            stats_dict = dev_status.get_status_dict()
+            self.logger.error(stats_dict)

--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -203,3 +203,8 @@ TCMU_SETTINGS = {
     "qfull_timeout": IntSetting("qfull_timeout", 0, 600, 5),
     "osd_op_timeout": IntSetting("osd_op_timeout", 0, 600, 30),
     "hw_max_sectors": IntSetting("hw_max_sectors", 1, 8192, 1024)}
+
+TCMU_DEV_STATUS_SETTINGS = {
+    "lock_lost_cnt_thresh": IntSetting("lock_lost_cnt_thresh", 1, 1000000, 12),
+    "status_check_interval": IntSetting("status_check_interval", 1, 600, 60),
+    "stable_state_reset_cnt": IntSetting("stable_state_reset_cnt", 1, 600, 3)}

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -11,7 +11,8 @@ import json
 import re
 
 from ceph_iscsi_config.gateway_setting import (TGT_SETTINGS, SYS_SETTINGS,
-                                               TCMU_SETTINGS)
+                                               TCMU_SETTINGS,
+                                               TCMU_DEV_STATUS_SETTINGS)
 
 
 # this module when imported preserves the global values
@@ -63,12 +64,17 @@ class Settings(object):
         self._add_attrs_from_defs(SYS_SETTINGS)
         self._add_attrs_from_defs(TGT_SETTINGS)
         self._add_attrs_from_defs(TCMU_SETTINGS)
+        self._add_attrs_from_defs(TCMU_DEV_STATUS_SETTINGS)
 
         if len(dataset) != 0:
             # If we have a file use it to override the defaults
             if config.has_section("config"):
                 self._override_attrs_from_conf(config.items("config"),
                                                SYS_SETTINGS)
+
+            if config.has_section("device_status"):
+                self._override_attrs_from_conf(config.items("device_status"),
+                                               TCMU_DEV_STATUS_SETTINGS)
 
             if config.has_section("target"):
                 all_settings = TGT_SETTINGS.copy()
@@ -129,6 +135,7 @@ class Settings(object):
         self._hash_settings(SYS_SETTINGS.keys(), sync_settings)
         self._hash_settings(TGT_SETTINGS.keys(), sync_settings)
         self._hash_settings(TCMU_SETTINGS.keys(), sync_settings)
+        self._hash_settings(TCMU_DEV_STATUS_SETTINGS.keys(), sync_settings)
 
         h = hashlib.sha256()
         h.update(json.dumps(sync_settings).encode('utf-8'))

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -627,8 +627,9 @@ class DiskPool(UIGroup):
 class Disk(UINode):
 
     display_attributes = ["image", "ceph_cluster", "pool", "wwn", "size_h",
-                          "feature_list", "snapshots", "owner", "backstore",
-                          "backstore_object_name", "control_values"]
+                          "feature_list", "snapshots", "owner", "current_owner",
+                          "state", "backstore", "backstore_object_name",
+                          "control_values"]
 
     def __init__(self, parent, image_id, image_config, size=None,
                  features=None, snapshots=None):
@@ -664,6 +665,7 @@ class Disk(UINode):
             self.parent.parent.disk_lookup[image_id] = self
 
         self._apply_config(image_config)
+        self._apply_status()
 
         if not size:
             # Size/features are not stored in the config, since it can be changed
@@ -684,6 +686,32 @@ class Disk(UINode):
         disk_map[self.image_id]['size'] = self.size
         disk_map[self.image_id]['size_h'] = self.size_h
 
+    def _apply_status(self):
+        disk_api = ('{}://localhost:{}/api/'
+                    'disk/{}'.format(self.http_mode,
+                                     settings.config.api_port, self.image_id))
+        self.logger.debug("disk GET status for {}".format(self.image_id))
+        api = APIRequest(disk_api)
+        api.get()
+
+        if api.response.status_code == 200:
+            info = api.response.json()
+            status = info.get("status")
+
+            self.__setattr__('current_owner', 'Unknown')
+            self.__setattr__('state', 'Unknown')
+
+            if status is None:
+                return
+
+            state = status.get('state')
+            if (state):
+                self.__setattr__('state', state)
+
+            owner = status.get('lock_owner')
+            if (owner):
+                self.__setattr__('current_owner', owner)
+
     def _apply_config(self, image_config):
         # set the remaining attributes based on the fields in the dict
         disk_map = self.parent.parent.disk_info
@@ -700,9 +728,28 @@ class Disk(UINode):
         if not self.exists:
             return 'NOT FOUND', False
 
-        msg = [self.image_id, "({})".format(self.size_h)]
+        status = True
 
-        return " ".join(msg), True
+        disk_api = ('{}://localhost:{}/api/'
+                    'disk/{}'.format(self.http_mode, settings.config.api_port,
+                                     self.image_id))
+
+        self.logger.debug("disk GET status for {}".format(self.image_id))
+        api = APIRequest(disk_api)
+        api.get()
+
+        state = "State unknown"
+        if api.response.status_code == 200:
+            info = api.response.json()
+            disk_status = info.get("status")
+            if disk_status:
+                state = disk_status.get("state")
+                if state != "Online":
+                    status = False
+
+        msg = [self.image_id, "({}, {})".format(state, self.size_h)]
+
+        return " ".join(msg), status
 
     def _parse_snapshots(self, snapshots):
         self.snapshots = ["{name} ({size})".format(name=s['name'],
@@ -741,6 +788,7 @@ class Disk(UINode):
         if not config:
             return
         self._apply_config(config['disks'][self.image_id])
+        self._apply_status()
 
     def _get_meta_data_tcmu(self):
         """

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -36,6 +36,7 @@ from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.utils import (normalize_ip_literal, resolve_ip_addresses,
                                      ip_addresses, read_os_release, encryption_available,
                                      CephiSCSIError, this_host)
+from ceph_iscsi_config.device_status import DeviceStatusWatcher
 
 from gwcli.utils import (APIRequest, valid_gateway, valid_client,
                          valid_credentials, get_remote_gateways, valid_snapshot_name,
@@ -1008,7 +1009,15 @@ def disk(pool, image):
     if request.method == 'GET':
 
         if image_id in config.config['disks']:
-            return jsonify(config.config["disks"][image_id]), 200
+            disk_dict = config.config["disks"][image_id]
+            global dev_status_watcher
+            disk_status = dev_status_watcher.get_dev_status(image_id)
+            if disk_status:
+                disk_dict['status'] = disk_status.get_status_dict()
+            else:
+                disk_dict['status'] = {}
+
+            return jsonify(disk_dict), 200
 
         else:
             return jsonify(message="rbd image {} not "
@@ -2893,6 +2902,10 @@ def main():
     if settings.config.log_to_file:
         log.addHandler(file_handler)
     log.addHandler(syslog_handler)
+
+    global dev_status_watcher
+    dev_status_watcher = DeviceStatusWatcher(logger)
+    dev_status_watcher.start()
 
     ceph_gw = CephiSCSIGateway(logger, config)
 


### PR DESCRIPTION
These patches allow rbd-target-api to check the tcmu-runner ceph status, mark a device as degraded and then report the state. It converts gwcli, but the rbd-target-api REST call can be used for other tools like dashboard.

These patches require tcmu-runner support:
https://github.com/open-iscsi/tcmu-runner/pull/626

Note:

I'm not working on ceph-iscsi anymore. I'm just posting this with the hope it's useful to the next maintainer. You can give me review comments, but I will not be updating the patchset :)