### PR TITLE
Fix gateway creation crash in python3

### DIFF
--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -440,7 +440,7 @@ class APIRequest(object):
                        "{}".format(self.args[0]))
                 self.data = Response()
                 self.data.status_code = 500
-                self.data._content = '{{"message": "{}" }}'.format(msg)
+                self.data._content = '{{"message": "{}" }}'.format(msg).encode('utf-8')
                 return self._get_response
             except Exception:
                 raise GatewayAPIError("Unknown error connecting to "


### PR DESCRIPTION
This propose fix issue: https://github.com/ceph/ceph-iscsi/issues/193

When setting api_host to localhost will hit below crash[1] in python3.
Json response should be encoded into utf-xx bytes[2].
And also add an error handling path for hostname api request.

[1]: 
/iscsi-target...ndev/gateways> create devstack-20-2 192.168.122.174
skipchecks=true
CMD: ../gateways/ create devstack-20-2 ['192.168.122.174'] nosync=False
skipchecks=true
OS version/package checks have been bypassed
Adding gateway, sync'ing 0 disk(s) and 0 client(s)
Gateway creation successful
Adding gw to UI
Traceback (most recent call last):
      File "/usr/bin/gwcli", line 194, in <module>
          main()
        File "/usr/bin/gwcli", line 125, in main
          shell.run_interactive()
        File "/usr/lib/python3/dist-packages/configshell_fb/shell.py",
      line 900, in run_interactive
          self._cli_loop()
        File "/usr/lib/python3/dist-packages/configshell_fb/shell.py",
      line 729, in _cli_loop
          self.run_cmdline(cmdline)
        File "/usr/lib/python3/dist-packages/configshell_fb/shell.py",
      line 843, in run_cmdline
          self._execute_command(path, command, pparams, kparams)
        File "/usr/lib/python3/dist-packages/configshell_fb/shell.py",
      line 818, in _execute_command
          result = target.execute_command(command, pparams, kparams)
        File "/usr/lib/python3/dist-packages/configshell_fb/node.py",
      line 1406, in execute_command
          return method(*pparams, **kparams)
        File "/usr/lib/python3/dist-packages/gwcli/gateway.py", line
      868, in ui_command_create
          gateway_hostname = api.response.json()['data']
        File "/usr/lib/python3/dist-packages/requests/models.py", line
      885, in json
          encoding = guess_json_utf(self.content)
        File "/usr/lib/python3/dist-packages/requests/utils.py", line
      871, in guess_json_utf
          nullcount = sample.count(_null)
      TypeError: must be str, not bytes

[2]: https://github.com/psf/requests/issues/4879

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>