### PR TITLE
spec: added dependency on ceph-common package

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -38,6 +38,7 @@ Obsoletes:      ceph-iscsi-config
 Obsoletes:      ceph-iscsi-cli
 
 Requires:       tcmu-runner >= 1.4.0
+Requires:       ceph-common >= 10.2.2
 %if 0%{?with_python2}
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools


### PR DESCRIPTION
The "ceph" CLI tool is required for removing blacklist entries.

Resolves: #192
Signed-off-by: Jason Dillaman <dillaman@redhat.com>