### PR TITLE
Support specified gateway config name

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -75,9 +75,11 @@ class Config(object):
 
     lock_time_limit = 30
 
-    def __init__(self, logger, cfg_name='gateway.conf', pool=None):
+    def __init__(self, logger, cfg_name=None, pool=None):
         self.logger = logger
         self.config_name = cfg_name
+        if self.config_name is None:
+            self.config_name = settings.config.gateway_conf
         if pool is None:
             pool = settings.config.pool
         self.pool = pool

--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -183,6 +183,7 @@ SYS_SETTINGS = {
     "debug": BoolSetting("debug", False),
     "minimum_gateways": IntSetting("minimum_gateways", 1, 9999, 2),
     "ceph_config_dir": StrSetting("ceph_config_dir", '/etc/ceph'),
+    "gateway_conf": StrSetting("gateway_conf", 'iscsi-gateway.conf'),
     "priv_key": StrSetting("priv_key", 'iscsi-gateway.key'),
     "pub_key": StrSetting("pub_key", 'iscsi-gateway-pub.key'),
     "prometheus_exporter": BoolSetting("prometheus_exporter", True),

--- a/iscsi-gateway.cfg_sample
+++ b/iscsi-gateway.cfg_sample
@@ -8,6 +8,7 @@ cluster_name = <ceph cluster name>
 
 # CephX client name
 # cluster_client_name = client.<rados_id>  # E.g.: client.admin
+# gateway_conf = iscsi-gateway.conf 
 
 # API settings.
 # The api supports a number of options that allow you to tailor it to your


### PR DESCRIPTION
Add the option to specify the gateway  configuration file, which can configure multiple gateways config  in the same pool.

Signed-off-by: zhang daolong <zhangdaolong@fiberhome.com>
