### PR TITLE
Fix rados cluster connection

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -35,11 +35,13 @@ class CephCluster(object):
         conf = settings.config.cephconf
 
         try:
-            self.cluster = rados.Rados(conffile=conf,
+            self.cluster = rados.Rados(clustername=settings.config.cluster_name,
+                                       conffile=conf,
                                        name=settings.config.cluster_client_name)
         except rados.Error as err:
             self.error = True
-            self.error_msg = "Invaid cluster_client_name or setting in {} - {}".format(conf, err)
+            self.error_msg = ("Invalid cluster_client_name, cluster_name "
+                              "or setting in {} - {}".format(conf, err))
             return
 
         try:


### PR DESCRIPTION
Without specifying the ceph cluster name via the clustername parameter
on the Rados class then the rbd target api doesn't start anymore with
recent ceph version (16.0.0+).
The cluster name value is already present in the settings via the
cluster_name option.

Closes: #208

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>