### PR TITLE
Rename blacklist to blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ The functionality provided by each module in the python package is summarised be
 | **utils** | common code called by multiple modules |
 
 The rbd-target-api daemon performs the following tasks;
-  1. At start up remove any osd blacklist entry that may apply to the running host  
-  2. Read the configuration object from Rados  
-  3. Process the configuration  
-  3.1 map rbd's to the host  
-  3.2 add rbd's to LIO  
-  3.3 Create the iscsi target, TPG's and port IP's  
-  3.4 Define clients (NodeACL's)  
-  3.5 add the required rbd images to clients  
+  1. At start up remove any osd blocklist entry that may apply to the running host
+  2. Read the configuration object from Rados
+  3. Process the configuration
+  3.1 map rbd's to the host
+  3.2 add rbd's to LIO
+  3.3 Create the iscsi target, TPG's and port IP's
+  3.4 Define clients (NodeACL's)
+  3.5 add the required rbd images to clients
   4. Export a REST API for system configuration.
 
 

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -26,70 +26,88 @@ class CephiSCSIGateway(object):
         else:
             self.hostname = this_host()
 
-    def ceph_rm_blacklist(self, blacklisted_ip):
+    def _run_ceph_cmd(self, cmd, stderr=None, shell=True):
+        if not stderr:
+            stderr = subprocess.STDOUT
+        try:
+            result = subprocess.check_output(cmd, stderr=stderr, shell=shell)
+        except subprocess.CalledProcessError as err:
+            return None, err
+        return result, None
+
+    def ceph_rm_blocklist(self, blocklisted_ip):
         """
-        Issue a ceph osd blacklist rm command for a given IP on this host
-        :param blacklisted_ip: IP address (str - dotted quad)
+        Issue a ceph osd blocklist rm command for a given IP on this host
+        :param blocklisted_ip: IP address (str - dotted quad)
         :return: boolean for success of the rm operation
         """
 
-        self.logger.info("Removing blacklisted entry for this host : "
-                         "{}".format(blacklisted_ip))
+        self.logger.info("Removing blocklisted entry for this host : "
+                         "{}".format(blocklisted_ip))
 
         conf = settings.config
-        try:
-            subprocess.check_output("ceph -n {client_name} --conf {cephconf} "
-                                    "osd blacklist rm {blacklisted_ip}".
-                                    format(blacklisted_ip=blacklisted_ip,
-                                           client_name=conf.cluster_client_name,
-                                           cephconf=conf.cephconf),
-                                    stderr=subprocess.STDOUT, shell=True)
-        except subprocess.CalledProcessError as err:
-            self.logger.critical("blacklist removal failed: {}. Run"
+        result, err = self._run_ceph_cmd(
+            "ceph -n {client_name} --conf {cephconf} osd blocklist rm "
+            "{blocklisted_ip}".format(blocklisted_ip=blocklisted_ip,
+                                      client_name=conf.cluster_client_name,
+                                      cephconf=conf.cephconf))
+        if err:
+            result, err = self._run_ceph_cmd(
+                "ceph -n {client_name} --conf {cephconf} osd blacklist rm "
+                "{blocklisted_ip}".format(blocklisted_ip=blocklisted_ip,
+                                          client_name=conf.cluster_client_name,
+                                          cephconf=conf.cephconf))
+
+        if err:
+            self.logger.critical("blocklist removal failed: {}. Run"
                                  " 'ceph -n {client_name} --conf {cephconf} "
-                                 "osd blacklist rm {blacklisted_ip}'".
+                                 "osd blocklist rm {blocklisted_ip}'".
                                  format(err.output.decode('utf-8').strip(),
-                                        blacklisted_ip=blacklisted_ip,
+                                        blocklisted_ip=blocklisted_ip,
                                         client_name=conf.cluster_client_name,
                                         cephconf=conf.cephconf))
             return False
 
-        self.logger.info("Successfully removed blacklist entry")
+        self.logger.info("Successfully removed blocklist entry")
         return True
 
-    def osd_blacklist_cleanup(self):
+    def osd_blocklist_cleanup(self):
         """
-        Process the osd's to see if there are any blacklist entries for this
+        Process the osd's to see if there are any blocklist entries for this
         node
-        :return: True, blacklist entries removed OK, False - problems removing
-        a blacklist
+        :return: True, blocklist entries removed OK, False - problems removing
+        a blocklist
         """
 
-        self.logger.info("Processing osd blacklist entries for this node")
+        self.logger.info("Processing osd blocklist entries for this node")
 
         cleanup_state = True
         conf = settings.config
 
-        try:
+        # NB. Need to use the stderr override to catch the output from
+        # the command
+        blocklist, err = self._run_ceph_cmd(
+            "ceph -n {client_name} --conf {cephconf} osd blocklist ls".
+            format(client_name=conf.cluster_client_name,
+                   cephconf=conf.cephconf))
 
-            # NB. Need to use the stderr override to catch the output from
-            # the command
-            blacklist = subprocess.check_output("ceph -n {client_name} --conf {cephconf} "
-                                                "osd blacklist ls"
-                                                .format(client_name=conf.cluster_client_name,
-                                                        cephconf=conf.cephconf),
-                                                shell=True,
-                                                stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
-            self.logger.critical("Failed to run 'ceph -n {client_name} --conf {cephconf} "
-                                 "osd blacklist ls'. Please resolve manually..."
-                                 .format(client_name=conf.cluster_client_name,
-                                         cephconf=conf.cephconf))
+        if err:
+            blocklist, err = self._run_ceph_cmd(
+                "ceph -n {client_name} --conf {cephconf} osd blacklist ls".
+                format(client_name=conf.cluster_client_name,
+                       cephconf=conf.cephconf))
+
+        if err:
+            self.logger.critical(
+                "Failed to run 'ceph -n {client_name} --conf {cephconf} "
+                "osd blocklist ls'. Please resolve manually..."
+                .format(client_name=conf.cluster_client_name,
+                        cephconf=conf.cephconf))
             cleanup_state = False
         else:
 
-            blacklist_output = blacklist.decode('utf-8').split('\n')[:-1]
-            if len(blacklist_output) > 1:
+            blocklist_output = blocklist.decode('utf-8').split('\n')[:-1]
+            if len(blocklist_output) > 1:
 
                 # We have entries to look for, so first build a list of ipv4
                 # addresses on this node
@@ -99,27 +117,27 @@ class CephiSCSIGateway(object):
                     ipv4_list += [dev['addr'] for dev in dev_info]
 
                 # process the entries. last entry is just null)
-                for blacklist_entry in blacklist_output:
+                for blocklist_entry in blocklist_output:
 
-                    # blacklist_output is not gauranteed to be in order returned
+                    # blocklist_output is not gauranteed to be in order returned
                     # from the ceph command. 'listed N entries' line could be
                     # at any index.
-                    if "listed" in blacklist_entry:
+                    if "listed" in blocklist_entry:
                         continue
 
                     # valid entries to process look like -
                     # 192.168.122.101:0/3258528596 2016-09-28 18:23:15.307227
-                    blacklisted_ip = blacklist_entry.split(':')[0]
-                    # Look for this hosts ipv4 address in the blacklist
+                    blocklisted_ip = blocklist_entry.split(':')[0]
+                    # Look for this hosts ipv4 address in the blocklist
 
-                    if blacklisted_ip in ipv4_list:
+                    if blocklisted_ip in ipv4_list:
                         # pass in the ip:port/nonce
-                        rm_ok = self.ceph_rm_blacklist(blacklist_entry.split(' ')[0])
+                        rm_ok = self.ceph_rm_blocklist(blocklist_entry.split(' ')[0])
                         if not rm_ok:
                             cleanup_state = False
                             break
             else:
-                self.logger.info("No OSD blacklist entries found")
+                self.logger.info("No OSD blocklist entries found")
 
         return cleanup_state
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2909,7 +2909,7 @@ def main():
 
     ceph_gw = CephiSCSIGateway(logger, config)
 
-    osd_state_ok = ceph_gw.osd_blacklist_cleanup()
+    osd_state_ok = ceph_gw.osd_blocklist_cleanup()
     if not osd_state_ok:
         sys.exit(16)
 


### PR DESCRIPTION
As a followup to Sage's ceph change[0], this patch changes:

  blacklist -> blocklist

The most important part is when we call `ceph osd blacklist {ls,rm}`
because it's now actaully `ceph osd blocklist ...`.

So this patch corrects this so ceph-iscsi will work in cephadm on
current master.

[0] - https://github.com/ceph/ceph/commit/dfd01d765304ed8783cef613930e65980d9aee23

Signed-off-by: Matthew Oliver <moliver@suse.com>