### PR TITLE
Add a strip to ListSetting.Normalize

### DIFF
--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -71,7 +71,7 @@ class ListSetting(Setting):
         return str(norm_val)
 
     def normalize(self, raw_val):
-        return raw_val.split(',') if raw_val else []
+        return [r.strip() for r in raw_val.split(',')] if raw_val else []
 
 
 class StrSetting(Setting):

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -5,13 +5,16 @@ import unittest
 
 from ceph_iscsi_config.settings import Settings
 from ceph_iscsi_config.target import GWTarget
+from ceph_iscsi_config.gateway_setting import SYS_SETTINGS
 
 
 class SettingsTest(unittest.TestCase):
 
     @staticmethod
-    def _normalize(controls):
-        return Settings.normalize_controls(controls, GWTarget.SETTINGS)
+    def _normalize(controls, settings=None):
+        if not settings:
+            settings = GWTarget.SETTINGS
+        return Settings.normalize_controls(controls, settings)
 
     def test_normalize_controls_int(self):
         self.assertEqual(
@@ -69,3 +72,16 @@ class SettingsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             SettingsTest._normalize({'immediate_data': 123})
         self.assertEqual('expected yes or no for immediate_data', str(cm.exception))
+
+    def test_normalise_list(self):
+        self.assertDictEqual(
+            SettingsTest._normalize(
+                {'trusted_ip_list': '10.1.1.1,10.1.1.2,10.1.1.3'},
+                SYS_SETTINGS),
+            {'trusted_ip_list': ['10.1.1.1', '10.1.1.2', '10.1.1.3']})
+
+        self.assertDictEqual(
+            SettingsTest._normalize(
+                {'trusted_ip_list': '10.1.1.1, 10.1.1.2 ,  10.1.1.3'},
+                SYS_SETTINGS),
+            {'trusted_ip_list': ['10.1.1.1', '10.1.1.2', '10.1.1.3']})


### PR DESCRIPTION
Currently when you specify a list in ceph-iscsi it _MUST_ be in the form
of 'item1,item2,item3'. Just delimitted by a comma (,). So if you
specify trusted_ip_list with spaces:

  trusted_ip_list: '10.1.1.1, 10.1.1.2'

This is actually fail as the space before 10.1.1.2 is retained.

This patch adds a strip() to the normalise call removing any extra
whitespace from the start and end of each item in the list.

Fixes: https://github.com/ceph/ceph-iscsi/issues/219
Signed-off-by: Matthew Oliver <moliver@suse.com>