### PR TITLE
Fix the default value for gateway_conf

### DIFF
--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -183,7 +183,7 @@ SYS_SETTINGS = {
     "debug": BoolSetting("debug", False),
     "minimum_gateways": IntSetting("minimum_gateways", 1, 9999, 2),
     "ceph_config_dir": StrSetting("ceph_config_dir", '/etc/ceph'),
-    "gateway_conf": StrSetting("gateway_conf", 'iscsi-gateway.conf'),
+    "gateway_conf": StrSetting("gateway_conf", 'gateway.conf'),
     "priv_key": StrSetting("priv_key", 'iscsi-gateway.key'),
     "pub_key": StrSetting("pub_key", 'iscsi-gateway-pub.key'),
     "prometheus_exporter": BoolSetting("prometheus_exporter", True),

--- a/iscsi-gateway.cfg_sample
+++ b/iscsi-gateway.cfg_sample
@@ -8,7 +8,7 @@ cluster_name = <ceph cluster name>
 
 # CephX client name
 # cluster_client_name = client.<rados_id>  # E.g.: client.admin
-# gateway_conf = iscsi-gateway.conf 
+# gateway_conf = gateway.conf
 
 # API settings.
 # The api supports a number of options that allow you to tailor it to your


### PR DESCRIPTION
The default value should be "gateway.conf".

Fixes: https://tracker.ceph.com/issues/48391
Signed-off-by: Xiubo Li <xiubli@redhat.com>