### PR TITLE
iscsi: write cert/key to temp files in mode 'w' to handle strings

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2842,7 +2842,7 @@ def get_ssl_files_from_mon():
         # https://bugs.python.org/issue16487 is resolved, we should be able
         # to simply use file-like objects and makes this much nicer.
 
-        tmp_f = tempfile.NamedTemporaryFile()
+        tmp_f = tempfile.NamedTemporaryFile(mode='w')
         tmp_f.write(data)
         tmp_f.flush()
         temp_files.append(tmp_f)


### PR DESCRIPTION
~~If the crt or key pulled from the mon store is a string object
this will encode it into bytes so it can be written to a temp file.
If the crt or key are already bytes it should have no effect~~
This change opens the temp files in 'w' mode rather than 'w+b' mode
so it can handle writes with strings

Was trying to add an iscsi service to a cephadm cluster using a spec file like so https://pastebin.com/nQ26yuWK
(same format for cert/key as is used for rgw service here https://github.com/ceph/ceph/pull/32951/files#diff-5b67faad3b657e6375889a9a68b5f18833c6ed77f29146875884d15453f81e90R13) 

The container would fail with this error

![image](https://user-images.githubusercontent.com/47704447/100925249-c12ff980-34af-11eb-8d74-910efc928e43.png)

~~This change gets around that issue and shouldn't cause any problems if a byte object is received to begin with.~~

Signed-off-by: Adam King <adking@redhat.com>