### PR TITLE
device_status: fix a typo

### DIFF
--- a/ceph_iscsi_config/device_status.py
+++ b/ceph_iscsi_config/device_status.py
@@ -124,7 +124,7 @@ class DeviceStatusWatcher(threading.Thread):
 
             svc = json.loads(outb).get('tcmu-runner')
             if svc is None:
-                self.logger.warning("there is no tcmu-runner data avaliable")
+                self.logger.warning("there is no tcmu-runner data available")
                 self.state = "Unknown"
                 continue
 


### PR DESCRIPTION
d0f023a6a19ab2ce619826bac4bf93ffb42dc272 introduced a small typo in a
warning message when there's no tcmu-runner data available.
This commit fixes it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>