### PR TITLE
gwcli: fix api_endpoint AttributeError

### DIFF
--- a/gwcli.py
+++ b/gwcli.py
@@ -105,7 +105,7 @@ def main():
     root_node.refresh()
     if root_node.error:
         print("Unable to contact the local API endpoint "
-              "({})".format(settings.config.api_endpoint))
+              "({})".format(root_node.local_api))
         sys.exit(-1)
 
     # Account for invocation which includes a command to run i.e. batch mode


### PR DESCRIPTION
AttributeError: 'Settings' object has no attribute 'api_endpoint'

Signed-off-by: Xiubo Li <xiubli@redhat.com>