### PR TITLE
gwcli: switch 403 state status to FORBIDDEN

### DIFF
--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -959,7 +959,7 @@ class Gateway(UINode):
                         "iscsi": "UP", "api": "UP"},
                   401: {"status": "UNAUTHORIZED",
                         "iscsi": "UNKNOWN", "api": "UP"},
-                  403: {"status": "UNAUTHORIZED",
+                  403: {"status": "FORBIDDEN",
                         "iscsi": "UNKNOWN", "api": "UP"},
                   500: {"status": "UNKNOWN",
                         "iscsi": "UNKNOWN", "api": "UNKNOWN"},


### PR DESCRIPTION
The 401 means the user/password mismatch, and 403 means the requested
ip address is not in the trusted ip list and use the "Forbidden" will
be clearer and could easily distinguish from the 401 error.

Signed-off-by: Xiubo Li <xiubli@redhat.com>