### PR TITLE
spec: mark the ceph-iscsi-tools package deprecated

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -36,6 +36,7 @@ BuildArch:      noarch
 
 Obsoletes:      ceph-iscsi-config
 Obsoletes:      ceph-iscsi-cli
+Obsoletes:      ceph-iscsi-tools
 
 Requires:       tcmu-runner >= 1.4.0
 Requires:       ceph-common >= 10.2.2


### PR DESCRIPTION
Ceph cluster now incorporates a generic metric gathering framework
within the OSDs and MGRs to provide built-in monitoring.

Signed-off-by: Xiubo Li <xiubli@redhat.com>