### PR TITLE
disable JSONIFY_PRETTYPRINT_REGULAR in flask app config

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -43,6 +43,8 @@ from gwcli.utils import (APIRequest, valid_gateway, valid_client,
                          GatewayAPIError)
 
 app = Flask(__name__)
+# workaround for https://github.com/pallets/flask/issues/2549
+app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
 
 def requires_basic_auth(f):

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -13,6 +13,8 @@ from ceph_iscsi_config.utils import CephiSCSIInval
 
 # Create a flask instance
 app = Flask(__name__)
+# workaround for https://github.com/pallets/flask/issues/2549
+app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
 
 @app.route("/", methods=["GET"])


### PR DESCRIPTION
The request.is_xhr method has been deprecated & removed, as it was
unreliable.

Signed-off-by: Xiubo Li <xiubli@redhat.com>