### PR TITLE
lun: fix valid_disk() return value

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -1079,7 +1079,7 @@ class LUN(GWObject):
                 settings.Settings.normalize_controls(kwargs['controls'],
                                                      LUN.SETTINGS[backstore])
             except ValueError as err:
-                return(err)
+                return "Unexpected or invalid controls: {}".format(err)
 
         if mode == 'delete':
 


### PR DESCRIPTION
valid_disk() should return either "ok" or an error description
string.  However, in case controls normalization fails, ValueError
object is returned.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>