### PR TITLE
fix client exists in the lio:when Client associated with multiple gateway

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -517,8 +517,12 @@ class GWClient(GWObject):
         """
 
         r = lio_root.RTSRoot()
-        client_list = [client.node_wwn for client in r.node_acls]
-        return self.iqn in client_list
+        clients_path = [client.path for client in r.node_acls]
+        for client_path in clients_path:
+            if self.iqn in client_path and self.target_iqn in client_path:
+                return True
+
+        return False
 
     def seed_config(self, config):
         """


### PR DESCRIPTION
when Client associated with multiple gateway,  when ceph-iscsi restart will clear all the resource, then start will check client exists in the lio, client will only create once，if client  associated  multiple gateway, The client always determines that it already exists，this add judge client on the another gateway create or not