### PR TITLE
rbd-target-api: switch to use distro to get the release version

### DIFF
--- a/ceph-iscsi.spec
+++ b/ceph-iscsi.spec
@@ -43,6 +43,7 @@ Requires:       ceph-common >= 10.2.2
 %if 0%{?with_python2}
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools
+Requires:       python2-distro
 Requires:       python-rados >= 10.2.2
 Requires:       python-rbd >= 10.2.2
 Requires:       python-netifaces >= 0.10.4
@@ -60,6 +61,7 @@ Requires:       python2-requests
 %else
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+Requires:       python3-distro
 Requires:       python3-rados >= 10.2.2
 Requires:       python3-rbd >= 10.2.2
 Requires:       python3-netifaces >= 0.10.4

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -259,7 +259,7 @@ class Clients(UIGroup):
                     status = False
                     break
 
-        return "Auth: {}, Hosts: {}".format(auth_stat_str, len(self.children)),\
+        return "Auth: {}, Hosts: {}".format(auth_stat_str, len(self.children)), \
             status
 
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2184,7 +2184,7 @@ def client(target_iqn, client_iqn):
                                         http_method='put',
                                         api_vars=api_vars)
 
-        return jsonify(message="client create/update {}".format(resp_text)),\
+        return jsonify(message="client create/update {}".format(resp_text)), \
             resp_code
 
     else:

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2777,8 +2777,8 @@ def pre_reqs_errors():
 
     if dist in valid_dists:
         if dist == 'rhel':
-            import platform
-            _, rel, _ = platform.linux_distribution(full_distribution_name=0)
+            import distro
+            rel = distro.version()
         # CentOS formats a release similar 7.4.1708
         rel = float(".".join(rel.split('.')[:2]))
         if rel < valid_dists[dist]:

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -41,7 +41,7 @@ class ChapTest(unittest.TestCase):
                 mock.patch.object(Config, '_read_config_object',
                                   return_value=current_config), \
                 mock.patch.object(Config, 'commit'), \
-                mock.patch("socket.gethostname", return_value='node2'),\
+                mock.patch("socket.gethostname", return_value='node2'), \
                 mock.patch("socket.getfqdn", return_value='node2.ceph.local'):
             config = Config(self.logger)
 


### PR DESCRIPTION
The 'platform.linux_distribution()' has been deprecated since python 3.7. And we should switch to use the distro.version(), distro.id() and distro.name() instead.