### PR TITLE
Prefer the newer unittest.mock from the standard library on Python 3

### DIFF
--- a/test/test_chap.py
+++ b/test/test_chap.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import mock
 import tempfile
 import sys
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization, hashes

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -6,7 +6,10 @@ import logging
 import sys
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 # We need to mock ceph libs python bindings because there's no
 # updated package in pypy


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.