### PR TITLE
device_status: avoid AttributeError when logging debugging info

### DIFF
--- a/ceph_iscsi_config/device_status.py
+++ b/ceph_iscsi_config/device_status.py
@@ -157,6 +157,5 @@ class DeviceStatusWatcher(threading.Thread):
                         dev_status.changed_state = False
 
             # debugging info
-            dev_status = self.get_dev_status(image_name)
-            stats_dict = dev_status.get_status_dict()
-            self.logger.debug(stats_dict)
+            status_dict = {k: v.get_status_dict() for k, v in self.status_lookup.items()}
+            self.logger.debug("device status {}".format(status_dict))

--- a/ceph_iscsi_config/device_status.py
+++ b/ceph_iscsi_config/device_status.py
@@ -125,7 +125,6 @@ class DeviceStatusWatcher(threading.Thread):
             svc = json.loads(outb).get('tcmu-runner')
             if svc is None:
                 self.logger.warning("there is no tcmu-runner data available")
-                self.state = "Unknown"
                 continue
 
             image_names_dict = {}


### PR DESCRIPTION
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 937, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/site-packages/ceph_iscsi_config/device_status.py", line 162, in run
    stats_dict = dev_status.get_status_dict()
AttributeError: 'NoneType' object has no attribute 'get_status_dict'
```